### PR TITLE
Apply macOS clippy suggestion.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=Cargo.toml --doc --no-default-features --features=svg,image,im
+          args: --manifest-path=Cargo.toml --doc --no-default-features --features=image,im
 
   # This tests the future rust compiler to catch errors ahead of time without
   # breaking CI

--- a/src/backend/mac/application.rs
+++ b/src/backend/mac/application.rs
@@ -75,7 +75,7 @@ impl Application {
 
             // Clean up the delegate
             let () = msg_send![self.ns_app, setDelegate: nil];
-            Box::from_raw(state_ptr); // Causes it to drop & dealloc automatically
+            drop(Box::from_raw(state_ptr)); // Causes it to drop & dealloc automatically
         }
     }
 

--- a/src/backend/mac/window.rs
+++ b/src/backend/mac/window.rs
@@ -374,7 +374,7 @@ lazy_static! {
             info!("view is dealloc'ed");
             unsafe {
                 let view_state: *mut c_void = *this.get_ivar("viewState");
-                Box::from_raw(view_state as *mut ViewState);
+                drop(Box::from_raw(view_state as *mut ViewState));
             }
         }
 


### PR DESCRIPTION
Apply clippy suggestions for the macOS backend, so that CI does not fail.