### PR TITLE
unpiet x11 backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
 
 [features]
-default = ["gtk"]
-gtk = ["gdk-sys", "glib-sys", "gtk-sys", "gtk-rs"]
+default = ["x11"]
+gtk = ["cairo-rs", "gdk-sys", "glib-sys", "gtk-sys", "gtk-rs"]
 x11 = [
     "ashpd",
     "bindgen",
-    "cairo-sys-rs",
     "futures",
     "nix",
     "pkg-config",
@@ -98,7 +97,7 @@ bitflags = "1.2.1"
 [target.'cfg(any(target_os = "freebsd", target_os="linux", target_os="openbsd"))'.dependencies]
 ashpd = { version = "0.3.0", optional = true }
 # TODO(x11/dependencies): only use feature "xcb" if using X11
-cairo-rs = { version = "0.14.0", default_features = false, features = ["xcb"] }
+cairo-rs = { version = "0.14.0", default_features = false, features = ["xcb"], optional = true }
 cairo-sys-rs = { version = "0.14.0", default_features = false, optional = true }
 futures = { version = "0.3.21", optional = true, features = ["executor"]}
 gdk-sys = { version = "0.14.0", optional = true }

--- a/src/backend/x11/application.rs
+++ b/src/backend/x11/application.rs
@@ -23,9 +23,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Error};
 use x11rb::connection::{Connection, RequestConnection};
-use x11rb::protocol::present::ConnectionExt as _;
 use x11rb::protocol::render::{self, ConnectionExt as _, Pictformat};
-use x11rb::protocol::xfixes::ConnectionExt as _;
 use x11rb::protocol::xproto::{
     self, ConnectionExt, CreateWindowAux, EventMask, Timestamp, Visualtype, WindowClass,
 };
@@ -173,8 +171,6 @@ pub(crate) struct Application {
     /// The write end of the "idle pipe", a pipe that allows the event loop to be woken up from
     /// other threads.
     idle_write: RawFd,
-    /// The major opcode of the Present extension, if it is supported.
-    present_opcode: Option<u8>,
     /// Support for the render extension in at least version 0.5?
     render_argb32_pictformat_cursor: Option<Pictformat>,
     /// Newest timestamp that we received
@@ -237,19 +233,6 @@ impl Application {
         }));
 
         let (idle_read, idle_write) = nix::unistd::pipe2(nix::fcntl::OFlag::O_NONBLOCK)?;
-
-        let present_opcode = if std::env::var_os("glazier_DISABLE_X11_PRESENT").is_some() {
-            // Allow disabling Present with an environment variable.
-            None
-        } else {
-            match Application::query_present_opcode(&connection) {
-                Ok(p) => p,
-                Err(e) => {
-                    tracing::info!("failed to find Present extension: {}", e);
-                    None
-                }
-            }
-        };
 
         let pictformats = connection.render_query_pict_formats()?;
         let render_create_cursor_supported = matches!(connection
@@ -344,7 +327,6 @@ impl Application {
             clipboard,
             primary,
             idle_write,
-            present_opcode,
             root_visual_type,
             argb_visual_type,
             atoms,
@@ -353,53 +335,6 @@ impl Application {
             render_argb32_pictformat_cursor,
             timestamp,
         })
-    }
-
-    // Check if the Present extension is supported, returning its opcode if it is.
-    fn query_present_opcode(conn: &Rc<XCBConnection>) -> Result<Option<u8>, Error> {
-        let query = conn
-            .query_extension(b"Present")?
-            .reply()
-            .context("query Present extension")?;
-
-        if !query.present {
-            return Ok(None);
-        }
-
-        let opcode = Some(query.major_opcode);
-
-        // If Present is there at all, version 1.0 should be supported. This code
-        // shouldn't have a real effect; it's just a sanity check.
-        let version = conn
-            .present_query_version(1, 0)?
-            .reply()
-            .context("query Present version")?;
-        tracing::info!(
-            "X server supports Present version {}.{}",
-            version.major_version,
-            version.minor_version,
-        );
-
-        // We need the XFIXES extension to use regions. This code looks like it's just doing a
-        // sanity check but it is *necessary*: XFIXES doesn't work until we've done version
-        // negotiation
-        // (https://www.x.org/releases/X11R7.7/doc/fixesproto/fixesproto.txt)
-        let version = conn
-            .xfixes_query_version(5, 0)?
-            .reply()
-            .context("query XFIXES version")?;
-        tracing::info!(
-            "X server supports XFIXES version {}.{}",
-            version.major_version,
-            version.minor_version,
-        );
-
-        Ok(opcode)
-    }
-
-    #[inline]
-    pub(crate) fn present_opcode(&self) -> Option<u8> {
-        self.present_opcode
     }
 
     /// Return the ARGB32 pictformat of the server, but only if RENDER's CreateCursor is supported
@@ -633,20 +568,6 @@ impl Application {
                     w.handle_configure_notify(ev)
                         .context("CONFIGURE_NOTIFY - failed to handle")?;
                 }
-            }
-            Event::PresentCompleteNotify(ev) => {
-                let w = self
-                    .window(ev.window)
-                    .context("COMPLETE_NOTIFY - failed to get window")?;
-                w.handle_complete_notify(ev)
-                    .context("COMPLETE_NOTIFY - failed to handle")?;
-            }
-            Event::PresentIdleNotify(ev) => {
-                let w = self
-                    .window(ev.window)
-                    .context("IDLE_NOTIFY - failed to get window")?;
-                w.handle_idle_notify(ev)
-                    .context("IDLE_NOTIFY - failed to handle")?;
             }
             Event::SelectionClear(ev) => {
                 self.clipboard

--- a/src/backend/x11/window.rs
+++ b/src/backend/x11/window.rs
@@ -16,7 +16,7 @@
 
 use std::cell::{Cell, RefCell};
 use std::collections::BinaryHeap;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::os::unix::io::RawFd;
 use std::panic::Location;
 use std::rc::{Rc, Weak};
@@ -25,23 +25,20 @@ use std::time::Instant;
 
 use crate::scale::Scalable;
 use anyhow::{anyhow, Context, Error};
-use cairo::{XCBConnection as CairoXCBConnection, XCBDrawable, XCBSurface, XCBVisualType};
-use tracing::{error, info, warn};
+use tracing::{error, warn};
 use x11rb::connection::Connection;
 use x11rb::errors::ReplyOrIdError;
 use x11rb::properties::{WmHints, WmHintsState, WmSizeHints};
-use x11rb::protocol::present::{CompleteNotifyEvent, ConnectionExt as _, IdleNotifyEvent};
-use x11rb::protocol::render::{ConnectionExt as _, Pictformat};
-use x11rb::protocol::xfixes::{ConnectionExt as _, Region as XRegion};
+use x11rb::protocol::render::Pictformat;
 use x11rb::protocol::xproto::{
     self, AtomEnum, ChangeWindowAttributesAux, ColormapAlloc, ConfigureNotifyEvent,
-    ConfigureWindowAux, ConnectionExt, CreateGCAux, EventMask, Gcontext, ImageFormat,
-    ImageOrder as X11ImageOrder, Pixmap, PropMode, Rectangle, Visualtype, WindowClass,
+    ConfigureWindowAux, ConnectionExt, EventMask, ImageOrder as X11ImageOrder, PropMode,
+    Visualtype, WindowClass,
 };
 use x11rb::wrapper::ConnectionExt as _;
 use x11rb::xcb_ffi::XCBConnection;
 
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle, XcbWindowHandle};
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle, XcbHandle};
 
 use crate::backend::shared::Timer;
 use crate::common_util::IdleCallback;
@@ -50,7 +47,6 @@ use crate::error::Error as ShellError;
 use crate::keyboard::{KeyState, Modifiers};
 use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 use crate::mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
-use crate::piet::{Piet, PietText, RenderContext};
 use crate::region::Region;
 use crate::scale::Scale;
 use crate::text::{simulate_input, Event};
@@ -188,35 +184,6 @@ impl WindowBuilder {
         // TODO(x11/menus): implement WindowBuilder::set_menu (currently a no-op)
     }
 
-    fn create_cairo_surface(
-        &self,
-        window_id: u32,
-        visual_type: &Visualtype,
-    ) -> Result<XCBSurface, Error> {
-        let conn = self.app.connection();
-        let cairo_xcb_connection = unsafe {
-            CairoXCBConnection::from_raw_none(
-                conn.get_raw_xcb_connection() as *mut cairo_sys::xcb_connection_t
-            )
-        };
-        let cairo_drawable = XCBDrawable(window_id);
-        let mut xcb_visual = xcb_visualtype_t::from(*visual_type);
-        let cairo_visual_type = unsafe {
-            XCBVisualType::from_raw_none(
-                &mut xcb_visual as *mut xcb_visualtype_t as *mut cairo_sys::xcb_visualtype_t,
-            )
-        };
-        let cairo_surface = XCBSurface::create(
-            &cairo_xcb_connection,
-            &cairo_drawable,
-            &cairo_visual_type,
-            self.size.width as i32,
-            self.size.height as i32,
-        )
-        .map_err(|status| anyhow!("Failed to create cairo surface: {}", status))?;
-        Ok(cairo_surface)
-    }
-
     // TODO(x11/menus): make menus if requested
     pub fn build(self) -> Result<WindowHandle, Error> {
         let conn = self.app.connection();
@@ -336,31 +303,7 @@ impl WindowBuilder {
             conn.free_colormap(colormap)?;
         }
 
-        // Allocate a graphics context (currently used only for copying pixels when present is
-        // unavailable).
-        let gc = conn.generate_id()?;
-        conn.create_gc(gc, id, &CreateGCAux::new())?
-            .check()
-            .context("create graphics context")?;
-
-        // TODO(x11/errors): Should do proper cleanup (window destruction etc) in case of error
-        let cairo_surface = RefCell::new(self.create_cairo_surface(id, &visual_type)?);
-        let present_data = match self.initialize_present_data(id) {
-            Ok(p) => Some(p),
-            Err(e) => {
-                info!("Failed to initialize present extension: {}", e);
-                None
-            }
-        };
         let handler = RefCell::new(self.handler.unwrap());
-        // When using present, we generally need two buffers (because after we present, we aren't
-        // allowed to use that buffer for a little while, and so we might want to render to the
-        // other one). Otherwise, we only need one.
-        let buf_count = if present_data.is_some() { 2 } else { 1 };
-        let buffers = RefCell::new(Buffers::new(
-            conn, id, buf_count, width_px, height_px, depth,
-        )?);
-
         // Initialize some properties
         let atoms = self.app.atoms();
         let pid = nix::unistd::Pid::this().as_raw();
@@ -470,10 +413,8 @@ impl WindowBuilder {
 
         let window = Rc::new(Window {
             id,
-            gc,
             app: self.app.clone(),
             handler,
-            cairo_surface,
             area: Cell::new(ScaledArea::from_px(size_px, scale)),
             scale: Cell::new(scale),
             min_size,
@@ -482,8 +423,6 @@ impl WindowBuilder {
             timer_queue: Mutex::new(BinaryHeap::new()),
             idle_queue: Arc::new(Mutex::new(Vec::new())),
             idle_pipe: self.app.idle_pipe(),
-            present_data: RefCell::new(present_data),
-            buffers,
             active_text_field: Cell::new(None),
             parent,
         });
@@ -499,39 +438,6 @@ impl WindowBuilder {
         self.app.add_window(id, window)?;
 
         Ok(handle)
-    }
-
-    fn initialize_present_data(&self, window_id: u32) -> Result<PresentData, Error> {
-        if self.app.present_opcode().is_some() {
-            let conn = self.app.connection();
-
-            // We use the CompleteNotify events to schedule the next frame, and the IdleNotify
-            // events to manage our buffers.
-            let id = conn.generate_id()?;
-            use x11rb::protocol::present::EventMask;
-            conn.present_select_input(
-                id,
-                window_id,
-                EventMask::COMPLETE_NOTIFY | EventMask::IDLE_NOTIFY,
-            )?
-            .check()
-            .context("set present event mask")?;
-
-            let region_id = conn.generate_id()?;
-            conn.xfixes_create_region(region_id, &[])
-                .context("create region")?;
-
-            Ok(PresentData {
-                serial: 0,
-                region: region_id,
-                waiting_on: None,
-                needs_present: false,
-                last_msc: None,
-                last_ust: None,
-            })
-        } else {
-            Err(anyhow!("no present opcode"))
-        }
     }
 }
 
@@ -554,10 +460,8 @@ impl WindowBuilder {
 //    case 2 smaller than the data accessible in case 1).
 pub(crate) struct Window {
     id: u32,
-    gc: Gcontext,
     app: Application,
     handler: RefCell<Box<dyn WinHandler>>,
-    cairo_surface: RefCell<XCBSurface>,
     area: Cell<ScaledArea>,
     scale: Cell<Scale>,
     // min size in px
@@ -571,94 +475,8 @@ pub(crate) struct Window {
     idle_queue: Arc<Mutex<Vec<IdleKind>>>,
     // Writing to this wakes up the event loop, so that it can run idle handlers.
     idle_pipe: RawFd,
-
-    /// When this is `Some(_)`, we use the X11 Present extension to present windows. This syncs all
-    /// presentation to vblank and it appears to prevent tearing (subject to various caveats
-    /// regarding broken video drivers).
-    ///
-    /// The Present extension works roughly like this: we submit a pixmap for presentation. It will
-    /// get drawn at the next vblank, and some time shortly after that we'll get a notification
-    /// that the drawing was completed.
-    ///
-    /// There are three ways that rendering can get triggered:
-    /// 1) We render a frame, and it signals to us that an animation is requested. In this case, we
-    ///     will render the next frame as soon as we get a notification that the just-presented
-    ///     frame completed. In other words, we use `CompleteNotifyEvent` to schedule rendering.
-    /// 2) We get an expose event telling us that a region got invalidated. In
-    ///    this case, we will render the next frame immediately unless we're already waiting for a
-    ///    completion notification. (If we are waiting for a completion notification, we just make
-    ///    a note to schedule a new frame once we get it.)
-    /// 3) Someone calls `invalidate` or `invalidate_rect` on us. We schedule ourselves to repaint
-    ///    in the idle loop. This is better than rendering straight away, because for example they
-    ///    might have called `invalidate` from their paint callback, and then we'd end up painting
-    ///    re-entrantively.
-    ///
-    /// This is probably not the best (or at least, not the lowest-latency) scheme we can come up
-    /// with, because invalidations that happen shortly after a vblank might need to wait 2 frames
-    /// before they appear. If we're getting lots of invalidations, it might be better to render more
-    /// than once per frame. Note that if we do, it will require some changes to part 1) above,
-    /// because if we render twice in a frame then we will get two completion notifications in a
-    /// row, so we don't want to present on both of them. The `msc` field of the completion
-    /// notification might be useful here, because it allows us to check how many frames have
-    /// actually been presented.
-    present_data: RefCell<Option<PresentData>>,
-    buffers: RefCell<Buffers>,
     active_text_field: Cell<Option<TextFieldToken>>,
     parent: Weak<Window>,
-}
-
-/// A collection of pixmaps for rendering to. This gets used in two different ways: if the present
-/// extension is enabled, we render to a pixmap and then present it. If the present extension is
-/// disabled, we render to a pixmap and then call `copy_area` on it (this probably isn't the best
-/// way to imitate double buffering, but it's the fallback anyway).
-struct Buffers {
-    /// A list of idle pixmaps. We take a pixmap from here for rendering to.
-    ///
-    /// When we're not using the present extension, all pixmaps belong in here; as soon as we copy
-    /// from one, we can use it again.
-    ///
-    /// When we submit a pixmap to present, we're not allowed to touch it again until we get a
-    /// corresponding IDLE_NOTIFY event. In my limited experiments this happens shortly after
-    /// vsync, meaning that we may want to start rendering the next pixmap before we get the old
-    /// one back. Therefore, we keep a list of pixmaps. We pop one each time we render, and push
-    /// one when we get IDLE_NOTIFY.
-    ///
-    /// Since the current code only renders at most once per vsync, two pixmaps seems to always be
-    /// enough. Nevertheless, we will allocate more on the fly if we need them. Note that rendering
-    /// more than once per vsync can only improve latency, because only the most recently-presented
-    /// pixmap will get rendered.
-    idle_pixmaps: Vec<Pixmap>,
-    /// A list of all the allocated pixmaps (including the idle ones).
-    all_pixmaps: Vec<Pixmap>,
-    /// The sizes of the pixmaps (they all have the same size). In order to avoid repeatedly
-    /// reallocating as the window size changes, we allow these to be bigger than the window.
-    width: u16,
-    height: u16,
-    /// The depth of the currently allocated pixmaps.
-    depth: u8,
-}
-
-/// The state involved in using X's [Present] extension.
-///
-/// [Present]: https://cgit.freedesktop.org/xorg/proto/presentproto/tree/presentproto.txt
-#[derive(Debug)]
-struct PresentData {
-    /// A monotonically increasing present request counter.
-    serial: u32,
-    /// The region that we use for telling X what to present.
-    region: XRegion,
-    /// Did we submit a present that hasn't completed yet? If so, this is its serial number.
-    waiting_on: Option<u32>,
-    /// We need to render another frame as soon as the current one is done presenting.
-    needs_present: bool,
-    /// The last MSC (media stream counter) that was completed. This can be used to diagnose
-    /// latency problems, because MSC is a frame counter: it increments once per frame. We should
-    /// be presenting on every frame, and storing the last completed MSC lets us know if we missed
-    /// one.
-    last_msc: Option<u64>,
-    /// The time at which the last frame was completed. The present protocol documentation doesn't
-    /// define the units, but it appears to be in microseconds.
-    last_ust: Option<u64>,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -667,11 +485,7 @@ pub struct CustomCursor(xproto::Cursor);
 impl Window {
     #[track_caller]
     fn with_handler<T, F: FnOnce(&mut dyn WinHandler) -> T>(&self, f: F) -> Option<T> {
-        if self.cairo_surface.try_borrow_mut().is_err()
-            || self.invalid.try_borrow_mut().is_err()
-            || self.present_data.try_borrow_mut().is_err()
-            || self.buffers.try_borrow_mut().is_err()
-        {
+        if self.invalid.try_borrow_mut().is_err() {
             error!("other RefCells were borrowed when calling into the handler");
             return None;
         }
@@ -732,42 +546,10 @@ impl Window {
             }
         };
         if new_size {
-            borrow_mut!(self.buffers)?.set_size(
-                self.app.connection(),
-                self.id,
-                size.width as u16,
-                size.height as u16,
-            );
-            borrow_mut!(self.cairo_surface)?
-                .set_size(size.width as i32, size.height as i32)
-                .map_err(|status| {
-                    anyhow!(
-                        "Failed to update cairo surface size to {:?}: {}",
-                        size,
-                        status
-                    )
-                })?;
             self.add_invalid_rect(size.to_dp(scale).to_rect())?;
             self.with_handler(|h| h.size(size.to_dp(scale)));
             self.with_handler(|h| h.scale(scale));
         }
-        Ok(())
-    }
-
-    // Ensure that our cairo context is targeting the right drawable, allocating one if necessary.
-    fn update_cairo_surface(&self) -> Result<(), Error> {
-        let mut buffers = borrow_mut!(self.buffers)?;
-        let pixmap = if let Some(p) = buffers.idle_pixmaps.last() {
-            *p
-        } else {
-            info!("ran out of idle pixmaps, creating a new one");
-            buffers.create_pixmap(self.app.connection(), self.id)?
-        };
-
-        let drawable = XCBDrawable(pixmap);
-        borrow_mut!(self.cairo_surface)?
-            .set_drawable(&drawable, buffers.width as i32, buffers.height as i32)
-            .map_err(|e| anyhow!("Failed to update cairo drawable: {}", e))?;
         Ok(())
     }
 
@@ -778,71 +560,11 @@ impl Window {
             return Ok(());
         }
 
-        self.update_cairo_surface()?;
         let invalid = std::mem::replace(&mut *borrow_mut!(self.invalid)?, Region::EMPTY);
-        {
-            let surface = borrow!(self.cairo_surface)?;
-            let cairo_ctx = cairo::Context::new(&surface).unwrap();
-            let scale = self.scale.get();
-            for rect in invalid.rects() {
-                let rect = rect.to_px(scale).round();
-                cairo_ctx.rectangle(rect.x0, rect.y0, rect.width(), rect.height());
-            }
-            cairo_ctx.clip();
-            cairo_ctx.scale(scale.x(), scale.y());
-            let mut piet_ctx = Piet::new(&cairo_ctx);
+        self.with_handler_and_dont_check_the_other_borrows(|handler| {
+            handler.paint(&invalid);
+        });
 
-            // We need to be careful with earlier returns here, because piet_ctx
-            // can panic if it isn't finish()ed. Also, we want to reset cairo's clip
-            // even on error.
-            //
-            // Note that we're borrowing the surface while calling the handler. This is ok, because
-            // we don't return control to the system or re-borrow the surface from any code that
-            // the client can call.
-            let result = self.with_handler_and_dont_check_the_other_borrows(|handler| {
-                handler.paint(&mut piet_ctx, &invalid);
-                piet_ctx
-                    .finish()
-                    .map_err(|e| anyhow!("Window::render - piet finish failed: {}", e))
-            });
-            let err = match result {
-                None => {
-                    // The handler borrow failed, so finish didn't get called.
-                    piet_ctx
-                        .finish()
-                        .map_err(|e| anyhow!("Window::render - piet finish failed: {}", e))
-                }
-                Some(e) => {
-                    // Finish might have errored, in which case we want to propagate it.
-                    e
-                }
-            };
-            cairo_ctx.reset_clip();
-
-            err?;
-        }
-
-        self.set_needs_present(false)?;
-
-        let mut buffers = borrow_mut!(self.buffers)?;
-        let pixmap = *buffers
-            .idle_pixmaps
-            .last()
-            .ok_or_else(|| anyhow!("after rendering, no pixmap to present"))?;
-        let scale = self.scale.get();
-        if let Some(present) = borrow_mut!(self.present_data)?.as_mut() {
-            present.present(self.app.connection(), pixmap, self.id, &invalid, scale)?;
-            buffers.idle_pixmaps.pop();
-        } else {
-            for rect in invalid.rects() {
-                let rect = rect.to_px(scale).round();
-                let (x, y) = (rect.x0 as i16, rect.y0 as i16);
-                let (w, h) = (rect.width() as u16, rect.height() as u16);
-                self.app
-                    .connection()
-                    .copy_area(pixmap, self.id, self.gc, x, y, x, y, w, h)?;
-            }
-        }
         Ok(())
     }
 
@@ -945,31 +667,18 @@ impl Window {
     /// "More-or-less" because if we're already waiting on a present, we defer the drawing until it
     /// completes.
     fn redraw_now(&self) -> Result<(), Error> {
-        if self.waiting_on_present()? {
-            self.set_needs_present(true)?;
-        } else {
-            self.render()?;
-        }
+        self.render()?;
         Ok(())
     }
 
     /// Schedule a redraw on the idle loop, or if we are waiting on present then schedule it for
     /// when the current present finishes.
     fn request_anim_frame(&self) {
-        if let Ok(true) = self.waiting_on_present() {
-            if let Err(e) = self.set_needs_present(true) {
-                error!(
-                    "Window::request_anim_frame - failed to schedule present: {}",
-                    e
-                );
-            }
-        } else {
-            let idle = IdleHandle {
-                queue: Arc::clone(&self.idle_queue),
-                pipe: self.idle_pipe,
-            };
-            idle.schedule_redraw();
-        }
+        let idle = IdleHandle {
+            queue: Arc::clone(&self.idle_queue),
+            pipe: self.idle_pipe,
+        };
+        idle.schedule_redraw();
     }
 
     fn invalidate(&self) {
@@ -1058,9 +767,7 @@ impl Window {
         .to_dp(self.scale.get());
 
         self.add_invalid_rect(rect)?;
-        if self.waiting_on_present()? {
-            self.set_needs_present(true)?;
-        } else if expose.count == 0 {
+        if expose.count == 0 {
             self.request_anim_frame();
         }
         Ok(())
@@ -1197,86 +904,6 @@ impl Window {
         self.size_changed(Size::new(event.width as f64, event.height as f64))
     }
 
-    pub fn handle_complete_notify(&self, event: &CompleteNotifyEvent) -> Result<(), Error> {
-        if let Some(present) = borrow_mut!(self.present_data)?.as_mut() {
-            // A little sanity check (which isn't worth an early return): we should only have
-            // one present request in flight, so we should only get notified about the request
-            // that we're waiting for.
-            if present.waiting_on != Some(event.serial) {
-                warn!(
-                    "Got a notify for serial {}, but waiting on {:?}",
-                    event.serial, present.waiting_on
-                );
-            }
-
-            // Check whether we missed presenting on any frames.
-            if let Some(last_msc) = present.last_msc {
-                if last_msc.wrapping_add(1) != event.msc {
-                    tracing::debug!(
-                        "missed a present: msc went from {} to {}",
-                        last_msc,
-                        event.msc
-                    );
-                    if let Some(last_ust) = present.last_ust {
-                        tracing::debug!("ust went from {} to {}", last_ust, event.ust);
-                    }
-                }
-            }
-
-            // Only store the last MSC if we're animating (if we aren't animating, missed MSCs
-            // aren't interesting).
-            present.last_msc = if present.needs_present {
-                Some(event.msc)
-            } else {
-                None
-            };
-            present.last_ust = Some(event.ust);
-            present.waiting_on = None;
-        }
-
-        if self.needs_present()? {
-            self.render()?;
-        }
-        Ok(())
-    }
-
-    pub fn handle_idle_notify(&self, event: &IdleNotifyEvent) -> Result<(), Error> {
-        if self.destroyed() {
-            return Ok(());
-        }
-
-        let mut buffers = borrow_mut!(self.buffers)?;
-        if buffers.all_pixmaps.contains(&event.pixmap) {
-            buffers.idle_pixmaps.push(event.pixmap);
-        } else {
-            // We must have reallocated the buffers while this pixmap was busy, so free it now.
-            // Regular freeing happens in `Buffers::free_pixmaps`.
-            self.app.connection().free_pixmap(event.pixmap)?;
-        }
-        Ok(())
-    }
-
-    fn waiting_on_present(&self) -> Result<bool, Error> {
-        Ok(borrow!(self.present_data)?
-            .as_ref()
-            .map(|p| p.waiting_on.is_some())
-            .unwrap_or(false))
-    }
-
-    fn set_needs_present(&self, val: bool) -> Result<(), Error> {
-        if let Some(present) = borrow_mut!(self.present_data)?.as_mut() {
-            present.needs_present = val;
-        }
-        Ok(())
-    }
-
-    fn needs_present(&self) -> Result<bool, Error> {
-        Ok(borrow!(self.present_data)?
-            .as_ref()
-            .map(|p| p.needs_present)
-            .unwrap_or(false))
-    }
-
     pub(crate) fn run_idle(&self) {
         let mut queue = Vec::new();
         std::mem::swap(&mut *self.idle_queue.lock().unwrap(), &mut queue);
@@ -1322,147 +949,6 @@ impl Window {
             let token = self.timer_queue.lock().unwrap().pop().unwrap().token();
             self.with_handler(|h| h.timer(token));
         }
-    }
-}
-
-impl Buffers {
-    fn new(
-        conn: &Rc<XCBConnection>,
-        window_id: u32,
-        buf_count: usize,
-        width: u16,
-        height: u16,
-        depth: u8,
-    ) -> Result<Buffers, Error> {
-        let mut ret = Buffers {
-            width,
-            height,
-            depth,
-            idle_pixmaps: Vec::new(),
-            all_pixmaps: Vec::new(),
-        };
-        ret.create_pixmaps(conn, window_id, buf_count)?;
-        Ok(ret)
-    }
-
-    /// Frees all the X pixmaps that we hold.
-    fn free_pixmaps(&mut self, conn: &Rc<XCBConnection>) {
-        // We can't touch pixmaps if the present extension is waiting on them, so only free the
-        // idle ones. We'll free the busy ones when we get notified that they're idle in `Window::handle_idle_notify`.
-        for &p in &self.idle_pixmaps {
-            log_x11!(conn.free_pixmap(p));
-        }
-        self.all_pixmaps.clear();
-        self.idle_pixmaps.clear();
-    }
-
-    fn set_size(&mut self, conn: &Rc<XCBConnection>, window_id: u32, width: u16, height: u16) {
-        // How big should the buffer be if we want at least x pixels? Rounding up to the next power
-        // of 2 has the potential to waste 75% of our memory (factor 2 in both directions), so
-        // instead we round up to the nearest number of the form 2^k or 3 * 2^k.
-        fn next_size(x: u16) -> u16 {
-            // We round up to the nearest multiple of `accuracy`, which is between x/2 and x/4.
-            // Don't bother rounding to anything smaller than 32 = 2^(7-1).
-            let accuracy = 1 << ((16 - x.leading_zeros()).max(7) - 2);
-            let mask = accuracy - 1;
-            (x + mask) & !mask
-        }
-
-        let width = next_size(width);
-        let height = next_size(height);
-        if (width, height) != (self.width, self.height) {
-            let count = self.all_pixmaps.len();
-            self.free_pixmaps(conn);
-            self.width = width;
-            self.height = height;
-            log_x11!(self.create_pixmaps(conn, window_id, count));
-        }
-    }
-
-    /// Creates a new pixmap for rendering to. The new pixmap will be first in line for rendering.
-    fn create_pixmap(&mut self, conn: &Rc<XCBConnection>, window_id: u32) -> Result<Pixmap, Error> {
-        let pixmap_id = conn.generate_id()?;
-        conn.create_pixmap(self.depth, pixmap_id, window_id, self.width, self.height)?;
-        self.all_pixmaps.push(pixmap_id);
-        self.idle_pixmaps.push(pixmap_id);
-        Ok(pixmap_id)
-    }
-
-    fn create_pixmaps(
-        &mut self,
-        conn: &Rc<XCBConnection>,
-        window_id: u32,
-        count: usize,
-    ) -> Result<(), Error> {
-        if !self.all_pixmaps.is_empty() {
-            self.free_pixmaps(conn);
-        }
-
-        for _ in 0..count {
-            self.create_pixmap(conn, window_id)?;
-        }
-        Ok(())
-    }
-}
-
-impl PresentData {
-    // We have already rendered into the active pixmap buffer. Present it to the
-    // X server, and then rotate the buffers.
-    fn present(
-        &mut self,
-        conn: &Rc<XCBConnection>,
-        pixmap: Pixmap,
-        window_id: u32,
-        region: &Region,
-        scale: Scale,
-    ) -> Result<(), Error> {
-        let x_rects: Vec<Rectangle> = region
-            .rects()
-            .iter()
-            .map(|r| {
-                let r = r.to_px(scale).round();
-                Rectangle {
-                    x: r.x0 as i16,
-                    y: r.y0 as i16,
-                    width: r.width() as u16,
-                    height: r.height() as u16,
-                }
-            })
-            .collect();
-
-        conn.xfixes_set_region(self.region, &x_rects[..])?;
-        conn.present_pixmap(
-            window_id,
-            pixmap,
-            self.serial,
-            // valid region of the pixmap
-            self.region,
-            // region of the window that must get updated
-            self.region,
-            // window-relative x-offset of the pixmap
-            0,
-            // window-relative y-offset of the pixmap
-            0,
-            // target CRTC
-            x11rb::NONE,
-            // wait fence
-            x11rb::NONE,
-            // idle fence
-            x11rb::NONE,
-            // present options
-            x11rb::protocol::present::Option::NONE.into(),
-            // target msc (0 means present at the next time that msc % divisor == remainder)
-            0,
-            // divisor
-            1,
-            // remainder
-            0,
-            // notifies
-            &[],
-        )?;
-        self.waiting_on = Some(self.serial);
-        self.serial += 1;
-        Ok(())
     }
 }
 
@@ -1732,10 +1218,6 @@ impl WindowHandle {
         }
     }
 
-    pub fn text(&self) -> PietText {
-        PietText::new()
-    }
-
     pub fn add_text_field(&self) -> TextFieldToken {
         TextFieldToken::next()
     }
@@ -1850,86 +1332,28 @@ impl WindowHandle {
 
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        let mut handle = XcbWindowHandle::empty();
+        let mut handle = XcbHandle::empty();
         handle.window = self.id;
         handle.visual_id = self.visual_id;
+
+        if let Some(window) = self.window.upgrade() {
+            handle.connection = window.app.connection().get_raw_xcb_connection();
+        } else {
+            // Documentation for HasRawWindowHandle encourages filling in all fields possible,
+            // leaving those empty that cannot be derived.
+            error!("Failed to get XCBConnection, returning incomplete handle");
+        }
+
         RawWindowHandle::Xcb(handle)
     }
 }
 
 fn make_cursor(
-    conn: &XCBConnection,
-    byte_order: X11ImageOrder,
-    root_window: u32,
-    argb32_format: Pictformat,
-    desc: &CursorDesc,
+    _conn: &XCBConnection,
+    _byte_order: X11ImageOrder,
+    _root_window: u32,
+    _argb32_format: Pictformat,
+    _desc: &CursorDesc,
 ) -> Result<Cursor, ReplyOrIdError> {
-    // BEGIN: Lots of code just to get the image into a RENDER Picture
-
-    fn multiply_alpha(color: u8, alpha: u8) -> u8 {
-        let (color, alpha) = (u16::from(color), u16::from(alpha));
-        let temp = color * alpha + 0x80u16;
-        ((temp + (temp >> 8)) >> 8) as u8
-    }
-
-    // No idea how to sanely get the pixel values, so I'll go with 'insane':
-    // Iterate over all pixels and build an array
-    let pixels = desc
-        .image
-        .pixel_colors()
-        .flat_map(|row| {
-            row.flat_map(|color| {
-                let (r, g, b, a) = color.as_rgba8();
-                // RENDER wants premultiplied alpha
-                let (r, g, b) = (
-                    multiply_alpha(r, a),
-                    multiply_alpha(g, a),
-                    multiply_alpha(b, a),
-                );
-                // piet gives us rgba in this order, the server expects an u32 with argb.
-                let (b0, b1, b2, b3) = match byte_order {
-                    X11ImageOrder::LSB_FIRST => (b, g, r, a),
-                    _ => (a, r, g, b),
-                };
-                // TODO Ownership and flat_map don't go well together :-(
-                vec![b0, b1, b2, b3]
-            })
-        })
-        .collect::<Vec<u8>>();
-    let width = desc.image.width().try_into().expect("Invalid cursor width");
-    let height = desc
-        .image
-        .height()
-        .try_into()
-        .expect("Invalid cursor height");
-
-    let pixmap = conn.generate_id()?;
-    let gc = conn.generate_id()?;
-    let picture = conn.generate_id()?;
-    conn.create_pixmap(32, pixmap, root_window, width, height)?;
-    conn.create_gc(gc, pixmap, &Default::default())?;
-
-    conn.put_image(
-        ImageFormat::Z_PIXMAP,
-        pixmap,
-        gc,
-        width,
-        height,
-        0,
-        0,
-        0,
-        32,
-        &pixels,
-    )?;
-    conn.render_create_picture(picture, pixmap, argb32_format, &Default::default())?;
-
-    conn.free_gc(gc)?;
-    conn.free_pixmap(pixmap)?;
-    // End: Lots of code just to get the image into a RENDER Picture
-
-    let cursor = conn.generate_id()?;
-    conn.render_create_cursor(cursor, picture, desc.hot.x as u16, desc.hot.y as u16)?;
-    conn.render_free_picture(picture)?;
-
-    Ok(Cursor::Custom(CustomCursor(cursor)))
+    Ok(Cursor::Arrow)
 }


### PR DESCRIPTION
- make x11 backend default because gtk backend does not support raw-window-handle
- remove custom cursors (needs piet)