### PR TITLE
Update kurbo dependency to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,8 @@ pnm = []
 serde = ["kurbo/serde"]
 
 [dependencies]
-# NOTE: When changing the piet or kurbo versions, ensure that
-#       the kurbo version included in piet is compatible with the kurbo version specified here.
-kurbo = "0.8.2"
+# Moving forward, this version should align with the kurbo version in peniko.
+kurbo = "0.9.0"
 
 tracing = "0.1.22"
 lazy_static = "1.4.0"


### PR DESCRIPTION
This syncs with peniko and gives us the new GAT stuff.