### PR TITLE
Initialize ns_window on mac

### DIFF
--- a/src/backend/mac/window.rs
+++ b/src/backend/mac/window.rs
@@ -1390,8 +1390,10 @@ impl WindowHandle {
 unsafe impl HasRawWindowHandle for WindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
         let nsv = self.nsview.load();
+        let window: id = unsafe { msg_send![*nsv, window] };
         let mut handle = AppKitWindowHandle::empty();
         handle.ns_view = *nsv as *mut _;
+        handle.ns_window = window as *mut _;
         RawWindowHandle::AppKit(handle)
     }
 }


### PR DESCRIPTION
We were setting ns_view but not ns_window, which was causing the query to fetch scale to fail, and thus dpi wrong.

I'm not 100% sure we should be calling the `window` method to get this, we could store the NSWindow pointer in the WindowHandle. The main reason we didn't do this was to support the VST use case, but that's not actively being developed.

In any case, I think this is probably "good enough."