### PR TITLE
Handle mouse_leave

### DIFF
--- a/src/backend/x11/application.rs
+++ b/src/backend/x11/application.rs
@@ -533,6 +533,12 @@ impl Application {
                     .context("MOTION_NOTIFY - failed to get window")?;
                 w.handle_motion_notify(ev)?;
             }
+            Event::LeaveNotify(ev) => {
+                let w = self
+                    .window(ev.event)
+                    .context("LEAVE_NOTIFY - failed to get window")?;
+                w.handle_leave_notify(ev)?;
+            }
             Event::ClientMessage(ev) => {
                 let w = self
                     .window(ev.window)

--- a/src/backend/x11/window.rs
+++ b/src/backend/x11/window.rs
@@ -884,19 +884,6 @@ impl Window {
         _leave_notify: &xproto::LeaveNotifyEvent,
     ) -> Result<(), Error> {
         self.with_handler(|h| h.mouse_leave());
-        // Alternately, handle mouse leave by generating a move event
-        //         let scale = self.scale.get();
-        //         let button = mouse_button(u8::from(leave_notify.detail));
-        //         let mouse_event = MouseEvent {
-        //             pos: Point::new(leave_notify.event_x as f64, leave_notify.event_y as f64).to_dp(scale),
-        //             buttons: mouse_buttons(leave_notify.state),
-        //             mods: key_mods(leave_notify.state),
-        //             count: 0,
-        //             focus: false,
-        //             button,
-        //             wheel_delta: Vec2::ZERO,
-        //         };
-        //         self.with_handler(|h| h.mouse_move(&mouse_event));
         Ok(())
     }
 

--- a/src/backend/x11/window.rs
+++ b/src/backend/x11/window.rs
@@ -240,7 +240,8 @@ impl WindowBuilder {
                 | EventMask::BUTTON_PRESS
                 | EventMask::BUTTON_RELEASE
                 | EventMask::POINTER_MOTION
-                | EventMask::FOCUS_CHANGE,
+                | EventMask::FOCUS_CHANGE
+                | EventMask::LEAVE_WINDOW,
         );
         if transparent {
             let colormap = conn.generate_id()?;
@@ -875,6 +876,27 @@ impl Window {
             wheel_delta: Vec2::ZERO,
         };
         self.with_handler(|h| h.mouse_move(&mouse_event));
+        Ok(())
+    }
+
+    pub fn handle_leave_notify(
+        &self,
+        _leave_notify: &xproto::LeaveNotifyEvent,
+    ) -> Result<(), Error> {
+        self.with_handler(|h| h.mouse_leave());
+        // Alternately, handle mouse leave by generating a move event
+        //         let scale = self.scale.get();
+        //         let button = mouse_button(u8::from(leave_notify.detail));
+        //         let mouse_event = MouseEvent {
+        //             pos: Point::new(leave_notify.event_x as f64, leave_notify.event_y as f64).to_dp(scale),
+        //             buttons: mouse_buttons(leave_notify.state),
+        //             mods: key_mods(leave_notify.state),
+        //             count: 0,
+        //             focus: false,
+        //             button,
+        //             wheel_delta: Vec2::ZERO,
+        //         };
+        //         self.with_handler(|h| h.mouse_move(&mouse_event));
         Ok(())
     }
 


### PR DESCRIPTION
This PR receives Xserver ` LeaveNotify` events and passes them to Glazier's `mouse_leave`, required to fix linebender/xilem#13 when Glazier's x11 backend is selected.