### PR TITLE
Update to use renamed vello crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,8 +138,7 @@ static_assertions = "1.1.0"
 test-log = { version = "0.2.5", features = ["trace"], default-features = false }
 tracing-subscriber = { version = "0.3.2", features = ["env-filter"] }
 unicode-segmentation = "1.7.0"
-piet-wgsl = { git = "https://github.com/linebender/piet-gpu" }
-piet-scene = { git = "https://github.com/linebender/piet-gpu" }
+vello = { git = "https://github.com/linebender/vello" }
 parley = { git = "https://github.com/dfrg/parley" }
 pollster = "0.2.5"
 

--- a/examples/shello.rs
+++ b/examples/shello.rs
@@ -254,13 +254,14 @@ pub fn render_anim_frame(scene: &mut Scene, fcx: &mut FontContext, i: u64) {
     let scale = (i as f64 * 0.01).sin() * 0.5 + 1.5;
     let mut lcx = parley::LayoutContext::new();
     let mut layout_builder =
-        lcx.ranged_builder(fcx, "Hello piet-gpu! ഹലോ ਸਤ ਸ੍ਰੀ ਅਕਾਲ مرحبا!", scale as f32);
+        lcx.ranged_builder(fcx, "Hello vello! ഹലോ ਸਤ ਸ੍ਰੀ ਅਕਾਲ مرحبا!", scale as f32);
     layout_builder.push_default(&parley::style::StyleProperty::FontSize(34.0));
     layout_builder.push(
         &parley::style::StyleProperty::Brush(ParleyBrush(Brush::Solid(Color::rgb8(255, 255, 0)))),
         6..10,
     );
-    layout_builder.push(&parley::style::StyleProperty::FontSize(48.0), 6..10);
+    layout_builder.push(&parley::style::StyleProperty::FontSize(48.0), 6..12);
+    layout_builder.push(&parley::style::StyleProperty::Brush(ParleyBrush(Color::YELLOW.into())), 6..12);
     layout_builder.push_default(&parley::style::StyleProperty::Brush(ParleyBrush(
         Brush::Solid(Color::rgb8(255, 255, 255)),
     )));

--- a/examples/shello.rs
+++ b/examples/shello.rs
@@ -261,7 +261,10 @@ pub fn render_anim_frame(scene: &mut Scene, fcx: &mut FontContext, i: u64) {
         6..10,
     );
     layout_builder.push(&parley::style::StyleProperty::FontSize(48.0), 6..12);
-    layout_builder.push(&parley::style::StyleProperty::Brush(ParleyBrush(Color::YELLOW.into())), 6..12);
+    layout_builder.push(
+        &parley::style::StyleProperty::Brush(ParleyBrush(Color::YELLOW.into())),
+        6..12,
+    );
     layout_builder.push_default(&parley::style::StyleProperty::Brush(ParleyBrush(
         Brush::Solid(Color::rgb8(255, 255, 255)),
     )));


### PR DESCRIPTION
This also fixes a lost device issue in the `shello` example.