### PR TITLE
X11: make clone cheap

### DIFF
--- a/src/backend/x11/application.rs
+++ b/src/backend/x11/application.rs
@@ -456,7 +456,7 @@ impl AppInner {
     }
 
     #[inline]
-    pub(crate) fn connection(&self) -> &Rc<XCBConnection> {
+    pub(crate) fn connection(&self) -> &XCBConnection {
         &self.connection
     }
 
@@ -814,7 +814,7 @@ fn drain_idle_pipe(idle_read: RawFd) -> Result<(), Error> {
 // This was taken, with minor modifications, from the xclock_utc example in the x11rb crate.
 // https://github.com/psychon/x11rb/blob/a6bd1453fd8e931394b9b1f2185fad48b7cca5fe/examples/xclock_utc.rs
 fn poll_with_timeout(
-    conn: &Rc<XCBConnection>,
+    conn: &XCBConnection,
     idle: RawFd,
     timer_timeout: Option<Instant>,
     idle_timeout: Instant,

--- a/src/backend/x11/screen.rs
+++ b/src/backend/x11/screen.rs
@@ -37,7 +37,7 @@ where
 pub(crate) fn get_monitors() -> Vec<Monitor> {
     let result = if let Some(app) = crate::Application::try_global() {
         let app = app.backend_app;
-        get_monitors_impl(app.connection().as_ref(), app.screen_num())
+        get_monitors_impl(app.connection(), app.screen_num())
     } else {
         let (conn, screen_num) = match x11rb::connect(None) {
             Ok(res) => res,

--- a/src/backend/x11/util.rs
+++ b/src/backend/x11/util.rs
@@ -14,8 +14,6 @@
 
 //! Miscellaneous utility functions for working with X11.
 
-use std::rc::Rc;
-
 use anyhow::{anyhow, Error};
 use x11rb::connection::RequestConnection;
 use x11rb::errors::ReplyError;
@@ -25,7 +23,7 @@ use x11rb::protocol::xproto::{Screen, Visualid, Visualtype, Window};
 use x11rb::xcb_ffi::XCBConnection;
 
 // See: https://github.com/rtbo/rust-xcb/blob/master/examples/randr_screen_modes.rs
-pub fn refresh_rate(conn: &Rc<XCBConnection>, window_id: Window) -> Option<f64> {
+pub fn refresh_rate(conn: &XCBConnection, window_id: Window) -> Option<f64> {
     let try_refresh_rate = || -> Result<f64, Error> {
         let reply = conn.randr_get_screen_resources(window_id)?.reply()?;
 

--- a/src/backend/x11/window.rs
+++ b/src/backend/x11/window.rs
@@ -372,7 +372,7 @@ impl WindowBuilder {
 
         let min_size = self.min_size.to_px(scale);
         log_x11!(size_hints(self.resizable, size_px, min_size)
-            .set_normal_hints(conn.as_ref(), id)
+            .set_normal_hints(conn, id)
             .context("set wm normal hints"));
 
         // TODO: set _NET_WM_STATE
@@ -384,7 +384,7 @@ impl WindowBuilder {
                 window::WindowState::Restored => WmHintsState::Normal,
             });
         }
-        log_x11!(hints.set(conn.as_ref(), id).context("set wm hints"));
+        log_x11!(hints.set(conn, id).context("set wm hints"));
 
         // set level
         {
@@ -583,7 +583,7 @@ impl Window {
 
     /// Set whether the window should be resizable
     fn resizable(&self, resizable: bool) {
-        let conn = self.app.connection().as_ref();
+        let conn = self.app.connection();
         log_x11!(size_hints(resizable, self.size().size_px(), self.min_size)
             .set_normal_hints(conn, self.id)
             .context("set normal hints"));


### PR DESCRIPTION
All other `Application` objects are cheap to clone. The X11 one had quite a lot of fields.

This probably doesn't have a big impact anywhere; it was on the path to trying to fix another bug...