### PR TITLE
Add wgpu triangle example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog 
+
+## Unreleased
+
+- Add wgpu triangle example ([#53] by [@lord])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ unicode-segmentation = "1.7.0"
 vello = { git = "https://github.com/linebender/vello" }
 parley = { git = "https://github.com/dfrg/parley" }
 pollster = "0.2.5"
+wgpu = "0.14.2"
 
 [build-dependencies]
 bindgen = { version = "0.60.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ on top of Glazier.
 Glazier does not provide drawing primitives and is intended to be agnostic to
 the drawing infrastructure. It uses [raw-window-handle] to provide an attachment
 point for the drawing code, a widely used abstraction in the Rust ecosystem. A
-top priority will be integrating with the [wgpu] ecosystem. In addition, we would
-gladly accept integration work to make [Piet] run on top of Glazier, but this is
-not a core priority.
+top priority will be integrating with the [wgpu](https://github.com/gfx-rs/wgpu)
+ecosystem. In addition, we would gladly accept integration work to make [Piet]
+run on top of Glazier, but this is not a core priority.
 
 We hope to integrate with [AccessKit] for accessibility.
 

--- a/examples/wgpu-triangle/main.rs
+++ b/examples/wgpu-triangle/main.rs
@@ -1,0 +1,270 @@
+use glazier::kurbo::Size;
+use glazier::{
+    Application, Cursor, FileDialogToken, FileInfo, IdleToken, KeyEvent, MouseEvent, Region,
+    Scalable, TimerToken, WinHandler, WindowHandle,
+};
+use std::any::Any;
+
+const WIDTH: usize = 2048;
+const HEIGHT: usize = 1536;
+
+use std::borrow::Cow;
+
+struct InnerWindowState {
+    window: WindowHandle,
+    device: wgpu::Device,
+    config: wgpu::SurfaceConfiguration,
+    surface: wgpu::Surface,
+    queue: wgpu::Queue,
+    render_pipeline: wgpu::RenderPipeline,
+}
+
+fn surface_size(handle: &WindowHandle) -> (u32, u32) {
+    let scale = handle.get_scale().unwrap_or_default();
+    let insets = handle.content_insets().to_px(scale);
+    let mut size = handle.get_size().to_px(scale);
+    size.width -= insets.x_value();
+    size.height -= insets.y_value();
+    (size.width as u32, size.height as u32)
+}
+
+impl InnerWindowState {
+    fn create(window: WindowHandle) -> Self {
+        let size = surface_size(&window);
+        let instance = wgpu::Instance::new(wgpu::Backends::all());
+        let surface = unsafe { instance.create_surface(&window) };
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::default(),
+            force_fallback_adapter: false,
+            // Request an adapter which can render to our surface
+            compatible_surface: Some(&surface),
+        }))
+        .expect("Failed to find an appropriate adapter");
+
+        // Create the logical device and command queue
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                label: None,
+                features: wgpu::Features::empty(),
+                // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
+                limits:
+                    wgpu::Limits::downlevel_webgl2_defaults().using_resolution(adapter.limits()),
+            },
+            None,
+        ))
+        .expect("Failed to create device");
+
+        // Load the shaders from disk
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("shader.wgsl"))),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: None,
+            bind_group_layouts: &[],
+            push_constant_ranges: &[],
+        });
+
+        let swapchain_format = surface.get_supported_formats(&adapter)[0];
+
+        let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: None,
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_main",
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_main",
+                targets: &[Some(swapchain_format.into())],
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+        });
+
+        let config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format: swapchain_format,
+            width: size.0,
+            height: size.1,
+            present_mode: wgpu::PresentMode::Fifo,
+            alpha_mode: surface.get_supported_alpha_modes(&adapter)[0],
+        };
+
+        surface.configure(&device, &config);
+
+        Self {
+            config,
+            surface,
+            window,
+            device,
+            render_pipeline,
+            queue,
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn schedule_render(&self) {
+        self.window
+            .get_idle_handle()
+            .unwrap()
+            .schedule_idle(IdleToken::new(0));
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn schedule_render(&self) {
+        self.window.invalidate();
+    }
+
+    fn draw(&mut self) {
+        let frame = self
+            .surface
+            .get_current_texture()
+            .expect("Failed to acquire next swap chain texture");
+        let view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        {
+            let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: None,
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
+                        store: true,
+                    },
+                })],
+                depth_stencil_attachment: None,
+            });
+            rpass.set_pipeline(&self.render_pipeline);
+            rpass.draw(0..3, 0..1);
+        }
+
+        self.queue.submit(Some(encoder.finish()));
+        frame.present();
+    }
+}
+
+fn main() {
+    let app = Application::new().unwrap();
+    let mut window_builder = glazier::WindowBuilder::new(app.clone());
+    window_builder.resizable(true);
+    window_builder.set_size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into());
+    window_builder.set_handler(Box::new(WindowState::new()));
+    let window_handle = window_builder.build().unwrap();
+    window_handle.show();
+    app.run(None);
+}
+
+struct WindowState {
+    inner: Option<InnerWindowState>,
+}
+
+impl WindowState {
+    fn new() -> Self {
+        Self { inner: None }
+    }
+}
+
+impl WinHandler for WindowState {
+    fn connect(&mut self, handle: &WindowHandle) {
+        let inner = InnerWindowState::create(handle.clone());
+        inner.schedule_render();
+        self.inner = Some(inner);
+    }
+
+    fn prepare_paint(&mut self) {}
+
+    fn paint(&mut self, _: &Region) {
+        let inner = self.inner.as_mut().unwrap();
+        inner.draw();
+        inner.schedule_render();
+    }
+
+    fn idle(&mut self, _: IdleToken) {
+        let inner = self.inner.as_mut().unwrap();
+        inner.draw();
+        inner.schedule_render();
+    }
+
+    fn command(&mut self, _id: u32) {}
+
+    fn open_file(&mut self, _token: FileDialogToken, file_info: Option<FileInfo>) {
+        println!("open file result: {:?}", file_info);
+    }
+
+    fn save_as(&mut self, _token: FileDialogToken, file: Option<FileInfo>) {
+        println!("save file result: {:?}", file);
+    }
+
+    fn key_down(&mut self, event: KeyEvent) -> bool {
+        println!("keydown: {:?}", event);
+        false
+    }
+
+    fn key_up(&mut self, event: KeyEvent) {
+        println!("keyup: {:?}", event);
+    }
+
+    fn wheel(&mut self, event: &MouseEvent) {
+        println!("mouse_wheel {:?}", event);
+    }
+
+    fn mouse_move(&mut self, event: &MouseEvent) {
+        self.inner
+            .as_mut()
+            .unwrap()
+            .window
+            .set_cursor(&Cursor::Arrow);
+        println!("mouse_move {:?}", event);
+    }
+
+    fn mouse_down(&mut self, event: &MouseEvent) {
+        println!("mouse_down {:?}", event);
+    }
+
+    fn mouse_up(&mut self, event: &MouseEvent) {
+        println!("mouse_up {:?}", event);
+    }
+
+    fn timer(&mut self, id: TimerToken) {
+        println!("timer fired: {:?}", id);
+    }
+
+    fn size(&mut self, _: Size) {
+        let inner = self.inner.as_mut().unwrap();
+        let size = surface_size(&inner.window);
+        inner.config.width = size.0;
+        inner.config.height = size.1;
+        inner.surface.configure(&inner.device, &inner.config);
+    }
+
+    fn got_focus(&mut self) {
+        println!("Got focus");
+    }
+
+    fn lost_focus(&mut self) {
+        println!("Lost focus");
+    }
+
+    fn request_close(&mut self) {
+        self.inner.as_ref().unwrap().window.close();
+    }
+
+    fn destroy(&mut self) {
+        Application::global().quit()
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/examples/wgpu-triangle/main.rs
+++ b/examples/wgpu-triangle/main.rs
@@ -1,8 +1,5 @@
 use glazier::kurbo::Size;
-use glazier::{
-    Application, Cursor, FileDialogToken, FileInfo, IdleToken, KeyEvent, MouseEvent, Region,
-    Scalable, TimerToken, WinHandler, WindowHandle,
-};
+use glazier::{Application, IdleToken, Region, Scalable, WinHandler, WindowHandle};
 use std::any::Any;
 
 const WIDTH: usize = 2048;
@@ -196,64 +193,12 @@ impl WinHandler for WindowState {
         inner.schedule_render();
     }
 
-    fn command(&mut self, _id: u32) {}
-
-    fn open_file(&mut self, _token: FileDialogToken, file_info: Option<FileInfo>) {
-        println!("open file result: {:?}", file_info);
-    }
-
-    fn save_as(&mut self, _token: FileDialogToken, file: Option<FileInfo>) {
-        println!("save file result: {:?}", file);
-    }
-
-    fn key_down(&mut self, event: KeyEvent) -> bool {
-        println!("keydown: {:?}", event);
-        false
-    }
-
-    fn key_up(&mut self, event: KeyEvent) {
-        println!("keyup: {:?}", event);
-    }
-
-    fn wheel(&mut self, event: &MouseEvent) {
-        println!("mouse_wheel {:?}", event);
-    }
-
-    fn mouse_move(&mut self, event: &MouseEvent) {
-        self.inner
-            .as_mut()
-            .unwrap()
-            .window
-            .set_cursor(&Cursor::Arrow);
-        println!("mouse_move {:?}", event);
-    }
-
-    fn mouse_down(&mut self, event: &MouseEvent) {
-        println!("mouse_down {:?}", event);
-    }
-
-    fn mouse_up(&mut self, event: &MouseEvent) {
-        println!("mouse_up {:?}", event);
-    }
-
-    fn timer(&mut self, id: TimerToken) {
-        println!("timer fired: {:?}", id);
-    }
-
     fn size(&mut self, _: Size) {
         let inner = self.inner.as_mut().unwrap();
         let size = surface_size(&inner.window);
         inner.config.width = size.0;
         inner.config.height = size.1;
         inner.surface.configure(&inner.device, &inner.config);
-    }
-
-    fn got_focus(&mut self) {
-        println!("Got focus");
-    }
-
-    fn lost_focus(&mut self) {
-        println!("Lost focus");
     }
 
     fn request_close(&mut self) {

--- a/examples/wgpu-triangle/shader.wgsl
+++ b/examples/wgpu-triangle/shader.wgsl
@@ -1,0 +1,11 @@
+@vertex
+fn vs_main(@builtin(vertex_index) in_vertex_index: u32) -> @builtin(position) vec4<f32> {
+    let x = f32(i32(in_vertex_index) - 1);
+    let y = f32(i32(in_vertex_index & 1u) * 2 - 1);
+    return vec4<f32>(x, y, 0.0, 1.0);
+}
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+}


### PR DESCRIPTION
Combines together the [wgpu triangle example](https://github.com/gfx-rs/wgpu/blob/v0.14.2/wgpu/examples/hello-triangle/main.rs) and the shello example to demonstrate wgpu working with glazier.

Tested on macos and windows.

<img src="https://user-images.githubusercontent.com/1976330/210124605-abd14498-7f1e-4907-a317-447b0f4c065e.png" width="500">
<img src="https://user-images.githubusercontent.com/1976330/210124607-96995f56-4834-4fb7-a34a-205dfaabed56.png" width="500">
