### PR TITLE
Fix clippy warnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -38,7 +38,7 @@ fn main() {
             xkbcommon
                 .include_paths
                 .iter()
-                .filter_map(|path| path.to_str().map(|s| format!("-I{}", s))),
+                .filter_map(|path| path.to_str().map(|s| format!("-I{s}"))),
         )
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.

--- a/src/backend/mac/window.rs
+++ b/src/backend/mac/window.rs
@@ -672,7 +672,7 @@ fn mouse_event(
     unsafe {
         let point = nsevent.locationInWindow();
         let view_point = view.convertPoint_fromView_(point, nil);
-        let pos = Point::new(view_point.x as f64, view_point.y as f64);
+        let pos = Point::new(view_point.x, view_point.y);
         let buttons = get_mouse_buttons(NSEvent::pressedMouseButtons(nsevent));
         let modifiers = make_modifiers(nsevent.modifierFlags());
         MouseEvent {
@@ -817,8 +817,8 @@ extern "C" fn scroll_wheel(this: &mut Object, _: Sel, nsevent: id) {
         let view_state: *mut c_void = *this.get_ivar("viewState");
         let view_state = &mut *(view_state as *mut ViewState);
         let (dx, dy) = {
-            let dx = -nsevent.scrollingDeltaX() as f64;
-            let dy = -nsevent.scrollingDeltaY() as f64;
+            let dx = -nsevent.scrollingDeltaX();
+            let dy = -nsevent.scrollingDeltaY();
             if nsevent.hasPreciseScrollingDeltas() == cocoa::base::YES {
                 (dx, dy)
             } else {
@@ -844,7 +844,7 @@ extern "C" fn pinch_event(this: &mut Object, _: Sel, nsevent: id) {
         let view_state = &mut *(view_state as *mut ViewState);
 
         let delta: CGFloat = msg_send![nsevent, magnification];
-        view_state.handler.zoom(delta as f64);
+        view_state.handler.zoom(delta);
     }
 }
 

--- a/src/backend/windows/window.rs
+++ b/src/backend/windows/window.rs
@@ -798,10 +798,10 @@ impl WndProc for MyWndProc {
                             if let Some(mut s) = s.as_mut() {
                                 let border = self.get_system_metric(SM_CXPADDEDBORDER);
                                 let frame = self.get_system_metric(SM_CYSIZEFRAME);
-                                s.rgrc[0].top += (border + frame) as i32;
-                                s.rgrc[0].right -= (border + frame) as i32;
-                                s.rgrc[0].left += (border + frame) as i32;
-                                s.rgrc[0].bottom -= (border + frame) as i32;
+                                s.rgrc[0].top += border + frame;
+                                s.rgrc[0].right -= border + frame;
+                                s.rgrc[0].left += border + frame;
+                                s.rgrc[0].bottom -= border + frame;
                             }
                         }
                     }


### PR DESCRIPTION
It seems like maybe the clippy lints changed with the most recent rust version; the build of my other pull requests is failing. This small change seems to make clippy happy again.