### PR TITLE
Add naga patch to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,3 +153,8 @@ required-features = ["accesskit"]
 
 [patch."https://github.com/dfrg/fount"]
 fount = { git = "https://github.com/jneem/fount" }
+
+[patch.crates-io]
+# Required for metal support to work on wgpu
+# TODO: remove when wgpu is upgraded to 0.15
+naga = { git = "https://github.com/gfx-rs/naga", rev = "ddcd5d3121150b2b1beee6e54e9125ff31aaa9a2" }


### PR DESCRIPTION
This mirrors the current patch as it exists in the [vello](https://github.com/linebender/vello/blob/dfde0936e5064ac8bb2765e1c3fdc1d5ac757a83/Cargo.toml) `Cargo.toml`.

Without this change, I get a shader error on `aarch64-apple-darwin`:

```
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_compute_pipeline
    Internal error: Metal: program_source:460:29: warning: unused variable '_e379'
                        int _e379 = uint(tile_ix) < 1 + (_buffer_sizes.size6 - 0 - 8) / 8 ? metal::atomic_fetch_add_explicit(&tiles[tile_ix].backdrop, backdrop, metal::memory_order_relaxed) : DefaultConstructible();
                            ^
program_source:513:70: error: cannot take the address of an rvalue of type 'metal::uint' (aka 'unsigned int')
                        uint _e450 = metal::atomic_exchange_explicit(&uint(tile_ix_1) < 1 + (_buffer_sizes.size6 - 0 - 8) / 8 ? tiles[tile_ix_1].segments : DefaultConstructible(), _e447, metal::memory_order_relaxed);
                                                                     ^~~~~~~~~~~~~~~~


', /Users/lord/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.2/src/backend/direct.rs:2403:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```