### PR TITLE
Restore hit_test_point method on InputHandler

### DIFF
--- a/src/backend/mac/text_input.rs
+++ b/src/backend/mac/text_input.rs
@@ -26,6 +26,7 @@ use std::ops::Range;
 use std::os::raw::c_uchar;
 
 use super::window::with_edit_lock_from_window;
+use crate::kurbo::Point;
 use crate::text::{
     Action, Affinity, Direction, InputHandler, Movement, Selection, VerticalMovement,
     WritingDirection,
@@ -212,17 +213,15 @@ pub extern "C" fn insert_text(this: &mut Object, _: Sel, text: id, replacement_r
 }
 
 pub extern "C" fn character_index_for_point(
-    _this: &mut Object,
+    this: &mut Object,
     _: Sel,
-    _point: NSPoint,
+    point: NSPoint,
 ) -> NSUInteger {
-    todo!()
-    // TODO: figure out how to do text hit testing without piet
-    // with_edit_lock_from_window(this, true, |edit_lock| {
-    //     let hit_test = edit_lock.hit_test_point(Point::new(point.x, point.y));
-    //     hit_test.idx as NSUInteger
-    // })
-    // .unwrap_or(0)
+    with_edit_lock_from_window(this, true, |edit_lock| {
+        let hit_test = edit_lock.hit_test_point(Point::new(point.x, point.y));
+        hit_test.idx as NSUInteger
+    })
+    .unwrap_or(0)
 }
 
 pub extern "C" fn first_rect_for_character_range(

--- a/src/text.rs
+++ b/src/text.rs
@@ -102,7 +102,7 @@
 //! doesn't allow for IME input, dead keys, etc.
 
 use crate::keyboard::{KbKey, KeyEvent};
-use crate::kurbo::Rect;
+use crate::kurbo::{Point, Rect};
 use crate::window::{TextFieldToken, WinHandler};
 use std::borrow::Cow;
 use std::ops::Range;
@@ -417,8 +417,8 @@ pub trait InputHandler {
     /// boundary.
     fn replace_range(&mut self, range: Range<usize>, text: &str);
 
-    // /// Given a `Point`, determine the corresponding text position.
-    // fn hit_test_point(&self, point: Point) -> HitTestPoint;
+    /// Given a `Point`, determine the corresponding text position.
+    fn hit_test_point(&self, point: Point) -> HitTestPoint;
 
     /// Returns the range, in UTF-8 code units, of the line (soft- or hard-wrapped)
     /// containing the byte specified by `index`.
@@ -870,4 +870,21 @@ pub enum Action {
     ///
     /// Triggered on most operating systems with escape.
     Cancel,
+}
+
+/// Result of hit testing a point in a block of text.
+///
+/// This type is returned by [`InputHandler::hit_test_point`].
+#[derive(Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct HitTestPoint {
+    /// The index representing the grapheme boundary closest to the `Point`.
+    pub idx: usize,
+    /// Whether or not the point was inside the bounds of the layout object.
+    ///
+    /// A click outside the layout object will still resolve to a position in the
+    /// text; for instance a click to the right edge of a line will resolve to the
+    /// end of that line, and a click below the last line will resolve to a
+    /// position in that line.
+    pub is_inside: bool,
 }


### PR DESCRIPTION
Fixes #8. Unfortunately it's not trivial to test this. I plan to restore the `edit_text.rs` example soon so that we have a working IME example we can use to make sure everything here is still working.

(Also definitely let me know if this flood of tiny PRs is getting annoying and I should stop, or if there's some other way I can be more helpful!)