### PR TITLE
Fix build on gtk feature

### DIFF
--- a/src/backend/gtk/clipboard.rs
+++ b/src/backend/gtk/clipboard.rs
@@ -148,7 +148,7 @@ impl Clipboard {
         targets
             .iter()
             // SAFETY: Atom::value() is 'self.0 as usize'. No idea why that is unsafe.
-            .map(|atom| format!("{} ({})", atom.name(), unsafe { atom.value() }))
+            .map(|atom| format!("{} ({})", atom.name(), atom.value()))
             .collect()
     }
 }

--- a/src/backend/gtk/dialog.rs
+++ b/src/backend/gtk/dialog.rs
@@ -47,7 +47,7 @@ pub(crate) fn get_file_dialog_path(
     };
     let title = options.title.as_deref().unwrap_or(title);
 
-    let mut dialog = gtk::FileChooserNativeBuilder::new()
+    let mut dialog = gtk::builders::FileChooserNativeBuilder::new()
         .transient_for(window)
         .title(title);
     if let Some(button_text) = &options.button_text {

--- a/src/backend/gtk/menu.rs
+++ b/src/backend/gtk/menu.rs
@@ -18,7 +18,7 @@ use gtk::gdk::ModifierType;
 use gtk::{
     AccelGroup, CheckMenuItem, Menu as GtkMenu, MenuBar as GtkMenuBar, MenuItem as GtkMenuItem,
 };
-use gtk_rs::SeparatorMenuItemBuilder;
+use gtk_rs::builders::SeparatorMenuItemBuilder;
 
 use gtk::prelude::{GtkMenuExt, GtkMenuItemExt, MenuShellExt, WidgetExt};
 

--- a/src/backend/gtk/screen.rs
+++ b/src/backend/gtk/screen.rs
@@ -20,8 +20,8 @@ use kurbo::{Point, Rect, Size};
 
 fn translate_gdk_rectangle(r: Rectangle) -> Rect {
     Rect::from_origin_size(
-        Point::new(r.x as f64, r.y as f64),
-        Size::new(r.width as f64, r.height as f64),
+        Point::new(r.x() as f64, r.y() as f64),
+        Size::new(r.width() as f64, r.height() as f64),
     )
 }
 


### PR DESCRIPTION
Fix #47
The code to create Piet context is removed. And `make_cursor` requires types from piet too, so I commented it out with TODO mentioning it.
shello example isn't working because it needs raw handles, but we can obtain it from GdkX11 and GdkWayland (there's no crate yet).