### PR TITLE
[x11] Switch mouse events from the core protocol to xinput.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ gtk-rs = { version = "0.15.5", features = ["v3_22"], package = "gtk", optional =
 glib-sys = { version = "0.15.10", optional = true }
 gtk-sys = { version = "0.15.3", optional = true }
 nix = { version = "0.25.0", optional = true }
-x11rb = { version = "0.10.1", features = ["allow-unsafe-code", "present", "render", "randr", "xfixes", "xkb", "resource_manager", "cursor"], optional = true }
+x11rb = { version = "0.11.1", features = ["allow-unsafe-code", "present", "render", "randr", "xfixes", "xkb", "resource_manager", "cursor", "xinput"], optional = true }
 wayland-client = { version = "0.29.5", optional = true }
 wayland-protocols = { version = "0.29.5", optional = true }
 wayland-cursor = { version = "0.29.5", optional = true }
@@ -138,7 +138,7 @@ static_assertions = "1.1.0"
 test-log = { version = "0.2.5", features = ["trace"], default-features = false }
 tracing-subscriber = { version = "0.3.2", features = ["env-filter"] }
 unicode-segmentation = "1.7.0"
-vello = { git = "https://github.com/linebender/vello", rev = "5f45c2bdfb59c1b9fbaaf52229bcd9f1105274da" }
+vello = { git = "https://github.com/linebender/vello", rev = "9721d4a6acd9cc7b852fbbcc33ecab9fba06d433" }
 parley = { git = "https://github.com/dfrg/parley", rev = "e4276b4d1001a050c07121f95ca255c771e9a641" }
 pollster = "0.2.5"
 wgpu = "0.14.2"

--- a/src/backend/gtk/dialog.rs
+++ b/src/backend/gtk/dialog.rs
@@ -28,7 +28,7 @@ fn file_filter(fs: &FileSpec) -> FileFilter {
     let ret = FileFilter::new();
     ret.set_name(Some(fs.name));
     for ext in fs.extensions {
-        ret.add_pattern(&format!("*.{}", ext));
+        ret.add_pattern(&format!("*.{ext}"));
     }
     ret
 }

--- a/src/backend/gtk/error.rs
+++ b/src/backend/gtk/error.rs
@@ -31,8 +31,8 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
-            Error::Error(err) => write!(f, "GTK Error: {}", err),
-            Error::BoolError(err) => write!(f, "GTK BoolError: {}", err),
+            Error::Error(err) => write!(f, "GTK Error: {err}"),
+            Error::BoolError(err) => write!(f, "GTK BoolError: {err}"),
         }
     }
 }

--- a/src/backend/wayland/application.rs
+++ b/src/backend/wayland/application.rs
@@ -449,7 +449,7 @@ impl Data {
             .queue
             .borrow_mut()
             .sync_roundtrip(&mut (), |evt, _, _| {
-                panic!("unexpected wayland event: {:?}", evt)
+                panic!("unexpected wayland event: {evt:?}")
             })
             .map_err(Error::fatal)?;
         Ok(())

--- a/src/backend/wayland/error.rs
+++ b/src/backend/wayland/error.rs
@@ -62,16 +62,15 @@ impl Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
-            Self::Connect(e) => write!(f, "could not connect to the wayland server: {:?}", e),
+            Self::Connect(e) => write!(f, "could not connect to the wayland server: {e:?}"),
             Self::Global { name, version, .. } => write!(
                 f,
-                "a required wayland global ({}@{}) was unavailable",
-                name, version
+                "a required wayland global ({name}@{version}) was unavailable"
             ),
-            Self::Fatal(e) => write!(f, "an unhandled error occurred: {:?}", e),
-            Self::Err(e) => write!(f, "an unhandled error occurred: {:?}", e),
+            Self::Fatal(e) => write!(f, "an unhandled error occurred: {e:?}"),
+            Self::Err(e) => write!(f, "an unhandled error occurred: {e:?}"),
             Self::String(e) => e.fmt(f),
-            Self::InvalidParent(id) => write!(f, "invalid parent window for popup: {:?}", id),
+            Self::InvalidParent(id) => write!(f, "invalid parent window for popup: {id:?}"),
         }
     }
 }

--- a/src/backend/wayland/keyboard.rs
+++ b/src/backend/wayland/keyboard.rs
@@ -353,7 +353,7 @@ impl Manager {
     }
 
     // TODO turn struct into a calloop event source.
-    pub(super) fn events<'a>(&self, handle: &'a calloop::LoopHandle<std::sync::Arc<Data>>) {
+    pub(super) fn events(&self, handle: &calloop::LoopHandle<std::sync::Arc<Data>>) {
         let rx = self.inner.apprx.borrow_mut().take().unwrap();
         handle
             .insert_source(rx, {

--- a/src/backend/wayland/surfaces/buffers.rs
+++ b/src/backend/wayland/surfaces/buffers.rs
@@ -475,7 +475,7 @@ impl Mmap {
         len: usize,
         private: bool,
     ) -> Result<Self, nix::Error> {
-        assert!(offset + len <= size, "{0} + {1} <= {2}", offset, len, size,);
+        assert!(offset + len <= size, "{offset} + {len} <= {size}",);
         let map_flags = if private {
             MapFlags::MAP_PRIVATE
         } else {

--- a/src/backend/windows/error.rs
+++ b/src/backend/windows/error.rs
@@ -69,9 +69,9 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
             Error::Hr(hr) => {
-                write!(f, "HRESULT 0x{:x}", hr)?;
+                write!(f, "HRESULT 0x{hr:x}")?;
                 if let Some(description) = hresult_description(*hr) {
-                    write!(f, ": {}", description)?;
+                    write!(f, ": {description}")?;
                 }
                 Ok(())
             }

--- a/src/backend/windows/mod.rs
+++ b/src/backend/windows/mod.rs
@@ -63,7 +63,7 @@ impl From<HRESULT> for Error {
 impl Debug for Error {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            Error::WinapiError(hr) => write!(f, "hresult {:x}", hr),
+            Error::WinapiError(hr) => write!(f, "hresult {hr:x}"),
         }
     }
 }
@@ -71,7 +71,7 @@ impl Debug for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            Error::WinapiError(hr) => write!(f, "hresult {:x}", hr),
+            Error::WinapiError(hr) => write!(f, "hresult {hr:x}"),
         }
     }
 }

--- a/src/backend/x11/dialog.rs
+++ b/src/backend/x11/dialog.rs
@@ -104,7 +104,7 @@ impl From<crate::FileSpec> for file_chooser::FileFilter {
     fn from(spec: crate::FileSpec) -> file_chooser::FileFilter {
         let mut filter = file_chooser::FileFilter::new(spec.name);
         for ext in spec.extensions {
-            filter = filter.glob(&format!("*.{}", ext));
+            filter = filter.glob(&format!("*.{ext}"));
         }
         filter
     }

--- a/src/backend/x11/mod.rs
+++ b/src/backend/x11/mod.rs
@@ -38,5 +38,6 @@ pub mod clipboard;
 pub mod dialog;
 pub mod error;
 pub mod menu;
+pub mod pointer;
 pub mod screen;
 pub mod window;

--- a/src/backend/x11/pointer.rs
+++ b/src/backend/x11/pointer.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+
+use anyhow::bail;
+use x11rb::{
+    protocol::xinput::{self, ConnectionExt as _, EventMask, InputInfo, XIEventMask},
+    xcb_ffi::XCBConnection,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct PointersState {
+    pub device_infos: HashMap<u8, DeviceInfo>,
+}
+
+#[derive(Clone, Debug)]
+pub struct DeviceInfo {
+    pub info: xinput::DeviceInfo,
+    pub name: Vec<u8>,
+    pub inputs: Vec<InputInfo>,
+}
+
+pub(crate) fn initialize_pointers(
+    conn: &XCBConnection,
+    window: u32,
+) -> anyhow::Result<PointersState> {
+    let version = conn.xinput_get_extension_version(b"xinput")?.reply()?;
+    if (version.server_major, version.server_minor) < (2, 2) {
+        // xinput 2.2 added multitouch; xorg has supported it since 2012
+        bail!("xinput version {version:?} found, but we require at least 2.2");
+    }
+
+    let devices = conn.xinput_list_input_devices()?.reply()?;
+
+    let mut device_infos = HashMap::new();
+    let mut infos = devices.infos.into_iter();
+
+    for (dev, name) in devices.devices.into_iter().zip(devices.names) {
+        tracing::debug!(
+            "device {}, named {}, use {:?}",
+            dev.device_id,
+            String::from_utf8_lossy(&name.name),
+            dev.device_use
+        );
+        device_infos.insert(
+            dev.device_id,
+            DeviceInfo {
+                info: dev,
+                name: name.name,
+                inputs: (&mut infos).take(dev.num_class_info as usize).collect(),
+            },
+        );
+    }
+    conn.xinput_xi_select_events(
+        window,
+        &[EventMask {
+            deviceid: 0,
+            mask: vec![
+                (XIEventMask::BUTTON_PRESS | XIEventMask::BUTTON_RELEASE | XIEventMask::MOTION),
+            ],
+        }],
+    )?
+    .check()?;
+
+    Ok(PointersState { device_infos })
+}

--- a/src/backend/x11/util.rs
+++ b/src/backend/x11/util.rs
@@ -39,10 +39,10 @@ pub fn refresh_rate(conn: &XCBConnection, window_id: Window) -> Option<f64> {
                 let flags = mode_info.mode_flags;
                 let vtotal = {
                     let mut val = mode_info.vtotal;
-                    if (flags & u32::from(ModeFlag::DOUBLE_SCAN)) != 0 {
+                    if u32::from(flags) & u32::from(ModeFlag::DOUBLE_SCAN) != 0 {
                         val *= 2;
                     }
-                    if (flags & u32::from(ModeFlag::INTERLACE)) != 0 {
+                    if u32::from(flags) & u32::from(ModeFlag::INTERLACE) != 0 {
                         val /= 2;
                     }
                     val


### PR DESCRIPTION
This will eventually let us support pointer events, but for now the only benefit is that it supports sub-pixel resolution on input devices that report it.

I've also bumped vello, because for some reason the old one was failing to compile with some missing peniko variants. I'm not sure how that slipped by, given that we're pinning the git revs now...