### PR TITLE
Update for the AccessKit node refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,13 +80,13 @@ keyboard-types = { version = "0.6.2", default_features = false }
 # Optional dependencies
 image = { version = "0.24.4", optional = true, default_features = false }
 raw-window-handle = { version = "0.5.0", default_features = false }
-accesskit = { version = "0.8.1", optional = true }
+accesskit = { version = "0.9.0", optional = true }
 once_cell = { version = "1", optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
 scopeguard = "1.1.0"
 wio = "0.2.2"
-accesskit_windows = { version = "0.10.0", optional = true }
+accesskit_windows = { version = "0.12.0", optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies.winapi]
 version = "0.3.9"
@@ -102,7 +102,7 @@ objc = "0.2.7"
 core-graphics = "0.22.0"
 foreign-types = "0.3.2"
 bitflags = "1.2.1"
-accesskit_macos = { version = "0.4.2", optional = true }
+accesskit_macos = { version = "0.5.0", optional = true }
 
 [target.'cfg(any(target_os = "freebsd", target_os="linux", target_os="openbsd"))'.dependencies]
 ashpd = { version = "0.3.2", optional = true }

--- a/examples/accesskit.rs
+++ b/examples/accesskit.rs
@@ -15,7 +15,8 @@
 use std::{any::Any, num::NonZeroU128};
 
 use accesskit::{
-    Action, ActionRequest, CheckedState, DefaultActionVerb, Node, NodeBuilder, NodeClassSet, NodeId, Rect, Role, Tree, TreeUpdate,
+    Action, ActionRequest, CheckedState, DefaultActionVerb, Node, NodeBuilder, NodeClassSet,
+    NodeId, Rect, Role, Tree, TreeUpdate,
 };
 
 use glazier::kurbo::Size;
@@ -59,10 +60,10 @@ fn build_checkbox(id: NodeId, checked: bool, classes: &mut NodeClassSet) -> Node
     builder.add_action(Action::Focus);
     builder.set_default_action_verb(DefaultActionVerb::Click);
     builder.set_checked_state(if checked {
-            CheckedState::True
-        } else {
-            CheckedState::False
-        });
+        CheckedState::True
+    } else {
+        CheckedState::False
+    });
     builder.build(classes)
 }
 
@@ -145,8 +146,16 @@ impl WinHandler for HelloState {
             builder.set_name(WINDOW_TITLE);
             builder.build(&mut self.node_classes)
         };
-        let checkbox_1 = build_checkbox(CHECKBOX_1_ID, self.checkbox_1_checked, &mut self.node_classes);
-        let checkbox_2 = build_checkbox(CHECKBOX_2_ID, self.checkbox_2_checked, &mut self.node_classes);
+        let checkbox_1 = build_checkbox(
+            CHECKBOX_1_ID,
+            self.checkbox_1_checked,
+            &mut self.node_classes,
+        );
+        let checkbox_2 = build_checkbox(
+            CHECKBOX_2_ID,
+            self.checkbox_2_checked,
+            &mut self.node_classes,
+        );
         TreeUpdate {
             nodes: vec![
                 (WINDOW_ID, root),


### PR DESCRIPTION
glazier proper only requires version bumps, but the example needed to be updated for the breaking API changes. (xilem will need to be updated as well.)