### PR TITLE
Update `vello` and sync `wgpu` to 0.15.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,10 +138,10 @@ static_assertions = "1.1.0"
 test-log = { version = "0.2.5", features = ["trace"], default-features = false }
 tracing-subscriber = { version = "0.3.2", features = ["env-filter"] }
 unicode-segmentation = "1.7.0"
-vello = { git = "https://github.com/linebender/vello", rev = "9721d4a6acd9cc7b852fbbcc33ecab9fba06d433" }
+vello = { git = "https://github.com/linebender/vello", rev = "5f59a2e8181a7d01f8753680676dd150b965728b" }
 parley = { git = "https://github.com/dfrg/parley", rev = "e4276b4d1001a050c07121f95ca255c771e9a641" }
 pollster = "0.2.5"
-wgpu = "0.14.2"
+wgpu = "0.15.0"
 
 [build-dependencies]
 bindgen = { version = "0.60.1", optional = true }
@@ -154,8 +154,3 @@ required-features = ["accesskit"]
 
 [patch."https://github.com/dfrg/fount"]
 fount = { git = "https://github.com/jneem/fount", rev = "361c76fecf813ebc64d2634d3df7bfb6089c6414" }
-
-[patch.crates-io]
-# Required for metal support to work on wgpu
-# TODO: remove when wgpu is upgraded to 0.15
-naga = { git = "https://github.com/gfx-rs/naga", rev = "ddcd5d3121150b2b1beee6e54e9125ff31aaa9a2" }

--- a/examples/wgpu-triangle/main.rs
+++ b/examples/wgpu-triangle/main.rs
@@ -28,8 +28,8 @@ fn surface_size(handle: &WindowHandle) -> (u32, u32) {
 impl InnerWindowState {
     fn create(window: WindowHandle) -> Self {
         let size = surface_size(&window);
-        let instance = wgpu::Instance::new(wgpu::Backends::all());
-        let surface = unsafe { instance.create_surface(&window) };
+        let instance = wgpu::Instance::default();
+        let surface = unsafe { instance.create_surface(&window) }.unwrap();
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::default(),
             force_fallback_adapter: false,
@@ -63,7 +63,8 @@ impl InnerWindowState {
             push_constant_ranges: &[],
         });
 
-        let swapchain_format = surface.get_supported_formats(&adapter)[0];
+        let caps = surface.get_capabilities(&adapter);
+        let swapchain_format = caps.formats[0];
 
         let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: None,
@@ -90,7 +91,8 @@ impl InnerWindowState {
             width: size.0,
             height: size.1,
             present_mode: wgpu::PresentMode::Fifo,
-            alpha_mode: surface.get_supported_alpha_modes(&adapter)[0],
+            alpha_mode: caps.alpha_modes[0],
+            view_formats: vec![],
         };
 
         surface.configure(&device, &config);


### PR DESCRIPTION
We have gone out of sync regarding `wgpu` as can be seen during compilation:

```
Compiling d3d12 v0.6.0
Compiling d3d12 v0.5.0
Compiling naga v0.11.0
Compiling naga v0.10.0 (https://github.com/gfx-rs/naga?rev=ddcd5d3121150b2b1beee6e54e9125ff31aaa9a2#ddcd5d31)
Compiling wgpu-hal v0.15.2
Compiling wgpu-hal v0.14.1
Compiling wgpu v0.14.2
Compiling wgpu v0.15.1
```

This PR updates `vello` to the latest version and syncs `wgpu` to 0.15.