### PR TITLE
[x11] Only listen to master pointers

### DIFF
--- a/src/backend/x11/pointer.rs
+++ b/src/backend/x11/pointer.rs
@@ -52,7 +52,7 @@ pub(crate) fn initialize_pointers(
     conn.xinput_xi_select_events(
         window,
         &[EventMask {
-            deviceid: 0,
+            deviceid: xinput::Device::ALL_MASTER.into(),
             mask: vec![
                 (XIEventMask::BUTTON_PRESS | XIEventMask::BUTTON_RELEASE | XIEventMask::MOTION),
             ],


### PR DESCRIPTION
For pointer events, we'll eventually want to listen to all pointers. For now, listening to only master pointers fixes duplicate events.

Fixes #73 