### PR TITLE
Automatically register macos CALayer delegate

### DIFF
--- a/examples/edit_text.rs
+++ b/examples/edit_text.rs
@@ -113,15 +113,6 @@ impl WindowState {
         }
     }
 
-    #[cfg(target_os = "macos")]
-    fn schedule_render(&self) {
-        self.handle
-            .get_idle_handle()
-            .unwrap()
-            .schedule_idle(IdleToken::new(0));
-    }
-
-    #[cfg(not(target_os = "macos"))]
     fn schedule_render(&self) {
         self.handle.invalidate();
     }
@@ -216,11 +207,6 @@ impl WinHandler for WindowState {
     fn prepare_paint(&mut self) {}
 
     fn paint(&mut self, _: &Region) {
-        self.render();
-        self.schedule_render();
-    }
-
-    fn idle(&mut self, _: IdleToken) {
         self.render();
         self.schedule_render();
     }

--- a/examples/edit_text.rs
+++ b/examples/edit_text.rs
@@ -5,7 +5,7 @@ use glazier::{
         Action, Affinity, Direction, Event, HitTestPoint, InputHandler, Movement, Selection,
         VerticalMovement,
     },
-    Application, IdleToken, KeyEvent, Region, Scalable, TextFieldToken, WinHandler, WindowHandle,
+    Application, KeyEvent, Region, Scalable, TextFieldToken, WinHandler, WindowHandle,
 };
 use parley::{FontContext, Layout};
 use std::any::Any;

--- a/examples/shello.rs
+++ b/examples/shello.rs
@@ -23,7 +23,6 @@ const HEIGHT: usize = 1536;
 fn main() {
     let app = Application::new().unwrap();
     let mut window_builder = glazier::WindowBuilder::new(app.clone());
-    window_builder.resizable(false);
     window_builder.set_size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into());
     window_builder.set_handler(Box::new(WindowState::new()));
     let window_handle = window_builder.build().unwrap();
@@ -57,15 +56,6 @@ impl WindowState {
         }
     }
 
-    #[cfg(target_os = "macos")]
-    fn schedule_render(&self) {
-        self.handle
-            .get_idle_handle()
-            .unwrap()
-            .schedule_idle(IdleToken::new(0));
-    }
-
-    #[cfg(not(target_os = "macos"))]
     fn schedule_render(&self) {
         self.handle.invalidate();
     }
@@ -123,10 +113,7 @@ impl WinHandler for WindowState {
         self.schedule_render();
     }
 
-    fn idle(&mut self, _: IdleToken) {
-        self.render();
-        self.schedule_render();
-    }
+    fn idle(&mut self, _: IdleToken) {}
 
     fn command(&mut self, _id: u32) {}
 

--- a/examples/wgpu-triangle/main.rs
+++ b/examples/wgpu-triangle/main.rs
@@ -107,15 +107,6 @@ impl InnerWindowState {
         }
     }
 
-    #[cfg(target_os = "macos")]
-    fn schedule_render(&self) {
-        self.window
-            .get_idle_handle()
-            .unwrap()
-            .schedule_idle(IdleToken::new(0));
-    }
-
-    #[cfg(not(target_os = "macos"))]
     fn schedule_render(&self) {
         self.window.invalidate();
     }
@@ -189,11 +180,7 @@ impl WinHandler for WindowState {
         inner.schedule_render();
     }
 
-    fn idle(&mut self, _: IdleToken) {
-        let inner = self.inner.as_mut().unwrap();
-        inner.draw();
-        inner.schedule_render();
-    }
+    fn idle(&mut self, _: IdleToken) {}
 
     fn size(&mut self, _: Size) {
         let inner = self.inner.as_mut().unwrap();


### PR DESCRIPTION
Fixes #64

This change allows the view object to speak the CALayerDelegate protocol, and automatically installs it as its own layer delegate if the view becomes layer-backed.

We also update the `invalidate` function to defer its `setNeedsLayer` call to prevent infinite loops when `invalidate` is called within a `WinHandler::paint()` implementation. `request_anim_frame` and `invalidate` now both have the same implementation; as far as I'm aware, the behavior wasn't actually different on macOS.

To test that this works, I removed the idle callback hack from both examples and saw both work correctly on macOS Monterey.