### PR TITLE
Copy AUTHORS from druid

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,26 @@
+# This is the list of Glazier authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
+Google LLC
+Raph Levien
+Hilmar Gústafsson
+Dmitry Borodin
+Kaiyin Zhong
+Kaur Kuut
+Leopold Luley
+Andrey Kabylin
+Robert Wittams
+Jaap Aarts
+Maximilian Köstler
+Bruno Dupuis
+Christopher Noel Hesse
+Marcin Zając
+Laura Gallo
+Tim Murison
+Manmeet Singh
+Simon Fell
+Nick Larsen
+Thomas McAndrew
+Jared O'Connell


### PR DESCRIPTION
Fixes #6 

I've chosen to just copy the AUTHORS file rather than looking at git blame output --- this list is quite short, and it seems better for copyright purposes to include an extra name unnecessarily than remove a name that should have been there.