### PR TITLE
Change WindowBuilder to a more conventional builder pattern

### DIFF
--- a/examples/accesskit.rs
+++ b/examples/accesskit.rs
@@ -238,8 +238,8 @@ fn main() {
 
     let app = Application::new().unwrap();
     let window = WindowBuilder::new(app.clone())
-        .set_handler(Box::new(HelloState::new()))
-        .set_title(WINDOW_TITLE)
+        .handler(Box::new(HelloState::new()))
+        .title(WINDOW_TITLE)
         .build()
         .unwrap();
 

--- a/examples/accesskit.rs
+++ b/examples/accesskit.rs
@@ -237,12 +237,11 @@ fn main() {
     tracing_subscriber::fmt().init();
 
     let app = Application::new().unwrap();
-    let mut builder = WindowBuilder::new(app.clone());
-    builder.set_handler(Box::new(HelloState::new()));
-    builder.set_title(WINDOW_TITLE);
-
-    let window = builder.build().unwrap();
-    window.show();
+    let window = WindowBuilder::new(app.clone())
+        .set_handler(Box::new(HelloState::new()))
+        .set_title(WINDOW_TITLE)
+        .build()
+        .unwrap();
 
     app.run(None);
 }

--- a/examples/edit_text.rs
+++ b/examples/edit_text.rs
@@ -34,12 +34,13 @@ const TEXT_Y: f64 = 100.0;
 
 fn main() {
     let app = Application::new().unwrap();
-    let mut window_builder = glazier::WindowBuilder::new(app.clone());
-    window_builder.resizable(true);
-    window_builder.set_size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into());
-    window_builder.set_handler(Box::new(WindowState::new()));
-    let window_handle = window_builder.build().unwrap();
-    window_handle.show();
+    let window = glazier::WindowBuilder::new(app.clone())
+        .resizable(true)
+        .set_size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into())
+        .set_handler(Box::new(WindowState::new()))
+        .build()
+        .unwrap();
+    window.show();
     app.run(None);
 }
 

--- a/examples/edit_text.rs
+++ b/examples/edit_text.rs
@@ -36,8 +36,8 @@ fn main() {
     let app = Application::new().unwrap();
     let window = glazier::WindowBuilder::new(app.clone())
         .resizable(true)
-        .set_size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into())
-        .set_handler(Box::new(WindowState::new()))
+        .size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into())
+        .handler(Box::new(WindowState::new()))
         .build()
         .unwrap();
     window.show();

--- a/examples/shello.rs
+++ b/examples/shello.rs
@@ -22,12 +22,13 @@ const HEIGHT: usize = 1536;
 
 fn main() {
     let app = Application::new().unwrap();
-    let mut window_builder = glazier::WindowBuilder::new(app.clone());
-    window_builder.resizable(false);
-    window_builder.set_size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into());
-    window_builder.set_handler(Box::new(WindowState::new()));
-    let window_handle = window_builder.build().unwrap();
-    window_handle.show();
+    let window = glazier::WindowBuilder::new(app.clone())
+        .resizable(false)
+        .set_size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into())
+        .set_handler(Box::new(WindowState::new()))
+        .build()
+        .unwrap();
+    window.show();
     app.run(None);
 }
 

--- a/examples/shello.rs
+++ b/examples/shello.rs
@@ -24,8 +24,8 @@ fn main() {
     let app = Application::new().unwrap();
     let window = glazier::WindowBuilder::new(app.clone())
         .resizable(false)
-        .set_size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into())
-        .set_handler(Box::new(WindowState::new()))
+        .size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into())
+        .handler(Box::new(WindowState::new()))
         .build()
         .unwrap();
     window.show();

--- a/examples/wgpu-triangle/main.rs
+++ b/examples/wgpu-triangle/main.rs
@@ -157,8 +157,8 @@ fn main() {
     let app = Application::new().unwrap();
     let window = glazier::WindowBuilder::new(app.clone())
         .resizable(true)
-        .set_size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into())
-        .set_handler(Box::new(WindowState::new()))
+        .size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into())
+        .handler(Box::new(WindowState::new()))
         .build()
         .unwrap();
     window.show();

--- a/examples/wgpu-triangle/main.rs
+++ b/examples/wgpu-triangle/main.rs
@@ -155,12 +155,13 @@ impl InnerWindowState {
 
 fn main() {
     let app = Application::new().unwrap();
-    let mut window_builder = glazier::WindowBuilder::new(app.clone());
-    window_builder.resizable(true);
-    window_builder.set_size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into());
-    window_builder.set_handler(Box::new(WindowState::new()));
-    let window_handle = window_builder.build().unwrap();
-    window_handle.show();
+    let window = glazier::WindowBuilder::new(app.clone())
+        .resizable(true)
+        .set_size((WIDTH as f64 / 2., HEIGHT as f64 / 2.).into())
+        .set_handler(Box::new(WindowState::new()))
+        .build()
+        .unwrap();
+    window.show();
     app.run(None);
 }
 

--- a/src/backend/gtk/window.rs
+++ b/src/backend/gtk/window.rs
@@ -243,17 +243,17 @@ impl WindowBuilder {
         }
     }
 
-    pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
+    pub fn handler(mut self, handler: Box<dyn WinHandler>) -> Self {
         self.handler = Some(handler);
         self
     }
 
-    pub fn set_size(mut self, size: Size) -> Self {
+    pub fn size(mut self, size: Size) -> Self {
         self.size = size;
         self
     }
 
-    pub fn set_min_size(mut self, size: Size) -> Self {
+    pub fn min_size(mut self, size: Size) -> Self {
         self.min_size = Some(size);
         self
     }
@@ -268,32 +268,32 @@ impl WindowBuilder {
         self
     }
 
-    pub fn set_transparent(mut self, transparent: bool) -> Self {
+    pub fn transparent(mut self, transparent: bool) -> Self {
         self.transparent = transparent;
         self
     }
 
-    pub fn set_position(mut self, position: Point) -> Self {
+    pub fn position(mut self, position: Point) -> Self {
         self.position = Some(position);
         self
     }
 
-    pub fn set_level(mut self, level: WindowLevel) -> Self {
+    pub fn level(mut self, level: WindowLevel) -> Self {
         self.level = Some(level);
         self
     }
 
-    pub fn set_window_state(mut self, state: window::WindowState) -> Self {
+    pub fn window_state(mut self, state: window::WindowState) -> Self {
         self.state = Some(state);
         self
     }
 
-    pub fn set_title(mut self, title: impl Into<String>) -> Self {
+    pub fn title(mut self, title: impl Into<String>) -> Self {
         self.title = title.into();
         self
     }
 
-    pub fn set_menu(mut self, menu: Menu) -> Self {
+    pub fn menu(mut self, menu: Menu) -> Self {
         self.menu = Some(menu);
         self
     }

--- a/src/backend/gtk/window.rs
+++ b/src/backend/gtk/window.rs
@@ -243,48 +243,59 @@ impl WindowBuilder {
         }
     }
 
-    pub fn set_handler(&mut self, handler: Box<dyn WinHandler>) {
+    pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
         self.handler = Some(handler);
+        self
     }
 
-    pub fn set_size(&mut self, size: Size) {
+    pub fn set_size(mut self, size: Size) -> Self {
         self.size = size;
+        self
     }
 
-    pub fn set_min_size(&mut self, size: Size) {
+    pub fn set_min_size(mut self, size: Size) -> Self {
         self.min_size = Some(size);
+        self
     }
 
-    pub fn resizable(&mut self, resizable: bool) {
+    pub fn resizable(mut self, resizable: bool) -> Self {
         self.resizable = resizable;
+        self
     }
 
-    pub fn show_titlebar(&mut self, show_titlebar: bool) {
+    pub fn show_titlebar(mut self, show_titlebar: bool) -> Self {
         self.show_titlebar = show_titlebar;
+        self
     }
 
-    pub fn set_transparent(&mut self, transparent: bool) {
+    pub fn set_transparent(mut self, transparent: bool) -> Self {
         self.transparent = transparent;
+        self
     }
 
-    pub fn set_position(&mut self, position: Point) {
+    pub fn set_position(mut self, position: Point) -> Self {
         self.position = Some(position);
+        self
     }
 
-    pub fn set_level(&mut self, level: WindowLevel) {
+    pub fn set_level(mut self, level: WindowLevel) -> Self {
         self.level = Some(level);
+        self
     }
 
-    pub fn set_window_state(&mut self, state: window::WindowState) {
+    pub fn set_window_state(mut self, state: window::WindowState) -> Self {
         self.state = Some(state);
+        self
     }
 
-    pub fn set_title(&mut self, title: impl Into<String>) {
+    pub fn set_title(mut self, title: impl Into<String>) -> Self {
         self.title = title.into();
+        self
     }
 
-    pub fn set_menu(&mut self, menu: Menu) {
+    pub fn set_menu(mut self, menu: Menu) -> Self {
         self.menu = Some(menu);
+        self
     }
 
     pub fn build(self) -> Result<WindowHandle, ShellError> {

--- a/src/backend/mac/window.rs
+++ b/src/backend/mac/window.rs
@@ -212,48 +212,59 @@ impl WindowBuilder {
         }
     }
 
-    pub fn set_handler(&mut self, handler: Box<dyn WinHandler>) {
+    pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
         self.handler = Some(handler);
+        self
     }
 
-    pub fn set_size(&mut self, size: Size) {
+    pub fn set_size(mut self, size: Size) -> Self {
         self.size = size;
+        self
     }
 
-    pub fn set_min_size(&mut self, size: Size) {
+    pub fn set_min_size(mut self, size: Size) -> Self {
         self.min_size = Some(size);
+        self
     }
 
-    pub fn resizable(&mut self, resizable: bool) {
+    pub fn resizable(mut self, resizable: bool) -> Self {
         self.resizable = resizable;
+        self
     }
 
-    pub fn show_titlebar(&mut self, show_titlebar: bool) {
+    pub fn show_titlebar(mut self, show_titlebar: bool) -> Self {
         self.show_titlebar = show_titlebar;
+        self
     }
 
-    pub fn set_transparent(&mut self, transparent: bool) {
+    pub fn set_transparent(mut self, transparent: bool) -> Self {
         self.transparent = transparent;
+        self
     }
 
-    pub fn set_level(&mut self, level: WindowLevel) {
+    pub fn set_level(mut self, level: WindowLevel) -> Self {
         self.level = Some(level);
+        self
     }
 
-    pub fn set_position(&mut self, position: Point) {
-        self.position = Some(position)
+    pub fn set_position(mut self, position: Point) -> Self {
+        self.position = Some(position);
+        self
     }
 
-    pub fn set_window_state(&mut self, state: WindowState) {
+    pub fn set_window_state(mut self, state: WindowState) -> Self {
         self.window_state = Some(state);
+        self
     }
 
-    pub fn set_title(&mut self, title: impl Into<String>) {
+    pub fn set_title(mut self, title: impl Into<String>) -> Self {
         self.title = title.into();
+        self
     }
 
-    pub fn set_menu(&mut self, menu: Menu) {
+    pub fn set_menu(mut self, menu: Menu) -> Self {
         self.menu = Some(menu);
+        self
     }
 
     pub fn build(self) -> Result<WindowHandle, Error> {

--- a/src/backend/mac/window.rs
+++ b/src/backend/mac/window.rs
@@ -212,17 +212,17 @@ impl WindowBuilder {
         }
     }
 
-    pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
+    pub fn handler(mut self, handler: Box<dyn WinHandler>) -> Self {
         self.handler = Some(handler);
         self
     }
 
-    pub fn set_size(mut self, size: Size) -> Self {
+    pub fn size(mut self, size: Size) -> Self {
         self.size = size;
         self
     }
 
-    pub fn set_min_size(mut self, size: Size) -> Self {
+    pub fn min_size(mut self, size: Size) -> Self {
         self.min_size = Some(size);
         self
     }
@@ -237,32 +237,32 @@ impl WindowBuilder {
         self
     }
 
-    pub fn set_transparent(mut self, transparent: bool) -> Self {
+    pub fn transparent(mut self, transparent: bool) -> Self {
         self.transparent = transparent;
         self
     }
 
-    pub fn set_level(mut self, level: WindowLevel) -> Self {
+    pub fn level(mut self, level: WindowLevel) -> Self {
         self.level = Some(level);
         self
     }
 
-    pub fn set_position(mut self, position: Point) -> Self {
+    pub fn position(mut self, position: Point) -> Self {
         self.position = Some(position);
         self
     }
 
-    pub fn set_window_state(mut self, state: WindowState) -> Self {
+    pub fn window_state(mut self, state: WindowState) -> Self {
         self.window_state = Some(state);
         self
     }
 
-    pub fn set_title(mut self, title: impl Into<String>) -> Self {
+    pub fn title(mut self, title: impl Into<String>) -> Self {
         self.title = title.into();
         self
     }
 
-    pub fn set_menu(mut self, menu: Menu) -> Self {
+    pub fn menu(mut self, menu: Menu) -> Self {
         self.menu = Some(menu);
         self
     }

--- a/src/backend/wayland/window.rs
+++ b/src/backend/wayland/window.rs
@@ -365,50 +365,61 @@ impl WindowBuilder {
         }
     }
 
-    pub fn set_handler(&mut self, handler: Box<dyn WinHandler>) {
+    pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
         self.handler = Some(handler);
+        self
     }
 
-    pub fn set_size(&mut self, size: Size) {
+    pub fn set_size(mut self, size: Size) -> Self {
         self.size = size;
+        self
     }
 
-    pub fn set_min_size(&mut self, size: Size) {
+    pub fn set_min_size(mut self, size: Size) -> Self {
         self.min_size = Some(size);
+        self
     }
 
-    pub fn resizable(&mut self, resizable: bool) {
+    pub fn resizable(mut self, resizable: bool) -> Self {
         self.resizable = resizable;
+        self
     }
 
-    pub fn show_titlebar(&mut self, show_titlebar: bool) {
+    pub fn show_titlebar(mut self, show_titlebar: bool) -> Self {
         self.show_titlebar = show_titlebar;
+        self
     }
 
-    pub fn set_transparent(&mut self, _transparent: bool) {
+    pub fn set_transparent(self, _transparent: bool) -> Self {
         tracing::warn!(
             "set_transparent unimplemented for wayland, it allows transparency by default"
         );
+        self
     }
 
-    pub fn set_position(&mut self, position: Point) {
+    pub fn set_position(mut self, position: Point) -> Self {
         self.position = Some(position);
+        self
     }
 
-    pub fn set_level(&mut self, level: WindowLevel) {
+    pub fn set_level(mut self, level: WindowLevel) -> Self {
         self.level = level;
+        self
     }
 
-    pub fn set_window_state(&mut self, state: window::WindowState) {
+    pub fn set_window_state(mut self, state: window::WindowState) -> Self {
         self.state = Some(state);
+        self
     }
 
-    pub fn set_title(&mut self, title: impl Into<String>) {
+    pub fn set_title(mut self, title: impl Into<String>) -> Self {
         self.title = title.into();
+        self
     }
 
-    pub fn set_menu(&mut self, menu: Menu) {
+    pub fn set_menu(mut self, menu: Menu) -> Self {
         self.menu = Some(menu);
+        self
     }
 
     pub fn build(self) -> Result<WindowHandle, ShellError> {

--- a/src/backend/wayland/window.rs
+++ b/src/backend/wayland/window.rs
@@ -365,17 +365,17 @@ impl WindowBuilder {
         }
     }
 
-    pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
+    pub fn handler(mut self, handler: Box<dyn WinHandler>) -> Self {
         self.handler = Some(handler);
         self
     }
 
-    pub fn set_size(mut self, size: Size) -> Self {
+    pub fn size(mut self, size: Size) -> Self {
         self.size = size;
         self
     }
 
-    pub fn set_min_size(mut self, size: Size) -> Self {
+    pub fn min_size(mut self, size: Size) -> Self {
         self.min_size = Some(size);
         self
     }
@@ -390,34 +390,34 @@ impl WindowBuilder {
         self
     }
 
-    pub fn set_transparent(self, _transparent: bool) -> Self {
+    pub fn transparent(self, _transparent: bool) -> Self {
         tracing::warn!(
-            "set_transparent unimplemented for wayland, it allows transparency by default"
+            "WindowBuilder::transparent is unimplemented for Wayland, it allows transparency by default"
         );
         self
     }
 
-    pub fn set_position(mut self, position: Point) -> Self {
+    pub fn position(mut self, position: Point) -> Self {
         self.position = Some(position);
         self
     }
 
-    pub fn set_level(mut self, level: WindowLevel) -> Self {
+    pub fn level(mut self, level: WindowLevel) -> Self {
         self.level = level;
         self
     }
 
-    pub fn set_window_state(mut self, state: window::WindowState) -> Self {
+    pub fn window_state(mut self, state: window::WindowState) -> Self {
         self.state = Some(state);
         self
     }
 
-    pub fn set_title(mut self, title: impl Into<String>) -> Self {
+    pub fn title(mut self, title: impl Into<String>) -> Self {
         self.title = title.into();
         self
     }
 
-    pub fn set_menu(mut self, menu: Menu) -> Self {
+    pub fn menu(mut self, menu: Menu) -> Self {
         self.menu = Some(menu);
         self
     }

--- a/src/backend/web/window.rs
+++ b/src/backend/web/window.rs
@@ -366,48 +366,59 @@ impl WindowBuilder {
     }
 
     /// This takes ownership, and is typically used with UiMain
-    pub fn set_handler(&mut self, handler: Box<dyn WinHandler>) {
+    pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
         self.handler = Some(handler);
+        self
     }
 
-    pub fn set_size(&mut self, _: Size) {
+    pub fn set_size(self, _: Size) -> Self {
         // Ignored
+        self
     }
 
-    pub fn set_min_size(&mut self, _: Size) {
+    pub fn set_min_size(self, _: Size) -> Self {
         // Ignored
+        self
     }
 
-    pub fn resizable(&mut self, _resizable: bool) {
+    pub fn resizable(self, _resizable: bool) -> Self {
         // Ignored
+        self
     }
 
-    pub fn show_titlebar(&mut self, _show_titlebar: bool) {
+    pub fn show_titlebar(self, _show_titlebar: bool) -> Self {
         // Ignored
+        self
     }
 
-    pub fn set_transparent(&mut self, _transparent: bool) {
+    pub fn set_transparent(self, _transparent: bool) -> Self {
         // Ignored
+        self
     }
 
-    pub fn set_position(&mut self, _position: Point) {
+    pub fn set_position(self, _position: Point) -> Self {
         // Ignored
+        self
     }
 
-    pub fn set_window_state(&self, _state: window::WindowState) {
+    pub fn set_window_state(self, _state: window::WindowState) -> Self {
         // Ignored
+        self
     }
 
-    pub fn set_level(&mut self, _level: WindowLevel) {
+    pub fn set_level(self, _level: WindowLevel) -> Self {
         // ignored
+        self
     }
 
-    pub fn set_title<S: Into<String>>(&mut self, title: S) {
+    pub fn set_title<S: Into<String>>(mut self, title: S) -> Self {
         self.title = title.into();
+        self
     }
 
-    pub fn set_menu(&mut self, menu: Menu) {
+    pub fn set_menu(mut self, menu: Menu) -> Self {
         self.menu = Some(menu);
+        self
     }
 
     pub fn build(self) -> Result<WindowHandle, Error> {

--- a/src/backend/web/window.rs
+++ b/src/backend/web/window.rs
@@ -366,17 +366,17 @@ impl WindowBuilder {
     }
 
     /// This takes ownership, and is typically used with UiMain
-    pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
+    pub fn handler(mut self, handler: Box<dyn WinHandler>) -> Self {
         self.handler = Some(handler);
         self
     }
 
-    pub fn set_size(self, _: Size) -> Self {
+    pub fn size(self, _: Size) -> Self {
         // Ignored
         self
     }
 
-    pub fn set_min_size(self, _: Size) -> Self {
+    pub fn min_size(self, _: Size) -> Self {
         // Ignored
         self
     }
@@ -391,32 +391,32 @@ impl WindowBuilder {
         self
     }
 
-    pub fn set_transparent(self, _transparent: bool) -> Self {
+    pub fn transparent(self, _transparent: bool) -> Self {
         // Ignored
         self
     }
 
-    pub fn set_position(self, _position: Point) -> Self {
+    pub fn position(self, _position: Point) -> Self {
         // Ignored
         self
     }
 
-    pub fn set_window_state(self, _state: window::WindowState) -> Self {
+    pub fn window_state(self, _state: window::WindowState) -> Self {
         // Ignored
         self
     }
 
-    pub fn set_level(self, _level: WindowLevel) -> Self {
+    pub fn level(self, _level: WindowLevel) -> Self {
         // ignored
         self
     }
 
-    pub fn set_title<S: Into<String>>(mut self, title: S) -> Self {
+    pub fn title<S: Into<String>>(mut self, title: S) -> Self {
         self.title = title.into();
         self
     }
 
-    pub fn set_menu(mut self, menu: Menu) -> Self {
+    pub fn menu(mut self, menu: Menu) -> Self {
         self.menu = Some(menu);
         self
     }

--- a/src/backend/windows/window.rs
+++ b/src/backend/windows/window.rs
@@ -1225,27 +1225,32 @@ impl WindowBuilder {
     }
 
     /// This takes ownership, and is typically used with UiMain
-    pub fn set_handler(&mut self, handler: Box<dyn WinHandler>) {
+    pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
         self.handler = Some(handler);
+        self
     }
 
-    pub fn set_size(&mut self, size: Size) {
+    pub fn set_size(mut self, size: Size) -> Self {
         self.size = Some(size);
+        self
     }
 
-    pub fn set_min_size(&mut self, size: Size) {
+    pub fn set_min_size(mut self, size: Size) -> Self {
         self.min_size = Some(size);
+        self
     }
 
-    pub fn resizable(&mut self, resizable: bool) {
+    pub fn resizable(mut self, resizable: bool) -> Self {
         self.resizable = resizable;
+        self
     }
 
-    pub fn show_titlebar(&mut self, show_titlebar: bool) {
+    pub fn show_titlebar(mut self, show_titlebar: bool) -> Self {
         self.show_titlebar = show_titlebar;
+        self
     }
 
-    pub fn set_transparent(&mut self, transparent: bool) {
+    pub fn set_transparent(mut self, transparent: bool) -> Self {
         // Transparency and Flip is only supported on Windows 8 and newer and
         // require DComposition
         if transparent {
@@ -1256,26 +1261,32 @@ impl WindowBuilder {
                 warn!("Transparency requires Windows 8 or newer");
             }
         }
+        self
     }
 
-    pub fn set_title<S: Into<String>>(&mut self, title: S) {
+    pub fn set_title<S: Into<String>>(mut self, title: S) -> Self {
         self.title = title.into();
+        self
     }
 
-    pub fn set_menu(&mut self, menu: Menu) {
+    pub fn set_menu(mut self, menu: Menu) -> Self {
         self.menu = Some(menu);
+        self
     }
 
-    pub fn set_position(&mut self, position: Point) {
+    pub fn set_position(mut self, position: Point) -> Self {
         self.position = Some(position);
+        self
     }
 
-    pub fn set_window_state(&mut self, state: window::WindowState) {
+    pub fn set_window_state(mut self, state: window::WindowState) -> Self {
         self.state = state;
+        self
     }
 
-    pub fn set_level(&mut self, level: WindowLevel) {
-        self.level = Some(level)
+    pub fn set_level(mut self, level: WindowLevel) -> Self {
+        self.level = Some(level);
+        self
     }
 
     pub fn build(self) -> Result<WindowHandle, Error> {

--- a/src/backend/windows/window.rs
+++ b/src/backend/windows/window.rs
@@ -1225,17 +1225,17 @@ impl WindowBuilder {
     }
 
     /// This takes ownership, and is typically used with UiMain
-    pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
+    pub fn handler(mut self, handler: Box<dyn WinHandler>) -> Self {
         self.handler = Some(handler);
         self
     }
 
-    pub fn set_size(mut self, size: Size) -> Self {
+    pub fn size(mut self, size: Size) -> Self {
         self.size = Some(size);
         self
     }
 
-    pub fn set_min_size(mut self, size: Size) -> Self {
+    pub fn min_size(mut self, size: Size) -> Self {
         self.min_size = Some(size);
         self
     }
@@ -1250,7 +1250,7 @@ impl WindowBuilder {
         self
     }
 
-    pub fn set_transparent(mut self, transparent: bool) -> Self {
+    pub fn transparent(mut self, transparent: bool) -> Self {
         // Transparency and Flip is only supported on Windows 8 and newer and
         // require DComposition
         if transparent {
@@ -1264,27 +1264,27 @@ impl WindowBuilder {
         self
     }
 
-    pub fn set_title<S: Into<String>>(mut self, title: S) -> Self {
+    pub fn title<S: Into<String>>(mut self, title: S) -> Self {
         self.title = title.into();
         self
     }
 
-    pub fn set_menu(mut self, menu: Menu) -> Self {
+    pub fn menu(mut self, menu: Menu) -> Self {
         self.menu = Some(menu);
         self
     }
 
-    pub fn set_position(mut self, position: Point) -> Self {
+    pub fn position(mut self, position: Point) -> Self {
         self.position = Some(position);
         self
     }
 
-    pub fn set_window_state(mut self, state: window::WindowState) -> Self {
+    pub fn window_state(mut self, state: window::WindowState) -> Self {
         self.state = state;
         self
     }
 
-    pub fn set_level(mut self, level: WindowLevel) -> Self {
+    pub fn level(mut self, level: WindowLevel) -> Self {
         self.level = Some(level);
         self
     }

--- a/src/backend/x11/window.rs
+++ b/src/backend/x11/window.rs
@@ -138,12 +138,12 @@ impl WindowBuilder {
         }
     }
 
-    pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
+    pub fn handler(mut self, handler: Box<dyn WinHandler>) -> Self {
         self.handler = Some(handler);
         self
     }
 
-    pub fn set_size(mut self, size: Size) -> Self {
+    pub fn size(mut self, size: Size) -> Self {
         // zero sized window results in server error
         self.size = if size.width == 0. || size.height == 0. {
             Size::new(1., 1.)
@@ -153,7 +153,7 @@ impl WindowBuilder {
         self
     }
 
-    pub fn set_min_size(mut self, min_size: Size) -> Self {
+    pub fn min_size(mut self, min_size: Size) -> Self {
         self.min_size = min_size;
         self
     }
@@ -169,34 +169,34 @@ impl WindowBuilder {
         self
     }
 
-    pub fn set_transparent(mut self, transparent: bool) -> Self {
+    pub fn transparent(mut self, transparent: bool) -> Self {
         self.transparent = transparent;
         self
     }
 
-    pub fn set_position(mut self, position: Point) -> Self {
+    pub fn position(mut self, position: Point) -> Self {
         self.position = Some(position);
         self
     }
 
-    pub fn set_level(mut self, level: WindowLevel) -> Self {
+    pub fn level(mut self, level: WindowLevel) -> Self {
         self.level = level;
         self
     }
 
-    pub fn set_window_state(mut self, state: window::WindowState) -> Self {
+    pub fn window_state(mut self, state: window::WindowState) -> Self {
         self.state = Some(state);
         self
     }
 
-    pub fn set_title<S: Into<String>>(mut self, title: S) -> Self {
+    pub fn title<S: Into<String>>(mut self, title: S) -> Self {
         self.title = title.into();
         self
     }
 
-    pub fn set_menu(self, _menu: Menu) -> Self {
+    pub fn menu(self, _menu: Menu) -> Self {
         // TODO(x11/menus): implement WindowBuilder::set_menu (currently a no-op)
-        warn!("WindowBuilder::set_menu is currently unimplemented for X11 backend.");
+        warn!("WindowBuilder::menu is currently unimplemented for X11 backend.");
         self
     }
 

--- a/src/backend/x11/window.rs
+++ b/src/backend/x11/window.rs
@@ -138,54 +138,66 @@ impl WindowBuilder {
         }
     }
 
-    pub fn set_handler(&mut self, handler: Box<dyn WinHandler>) {
+    pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
         self.handler = Some(handler);
+        self
     }
 
-    pub fn set_size(&mut self, size: Size) {
+    pub fn set_size(mut self, size: Size) -> Self {
         // zero sized window results in server error
         self.size = if size.width == 0. || size.height == 0. {
             Size::new(1., 1.)
         } else {
             size
         };
+        self
     }
 
-    pub fn set_min_size(&mut self, min_size: Size) {
+    pub fn set_min_size(mut self, min_size: Size) -> Self {
         self.min_size = min_size;
+        self
     }
 
-    pub fn resizable(&mut self, resizable: bool) {
+    pub fn resizable(mut self, resizable: bool) -> Self {
         self.resizable = resizable;
+        self
     }
 
-    pub fn show_titlebar(&mut self, _show_titlebar: bool) {
+    pub fn show_titlebar(self, _show_titlebar: bool) -> Self {
         // not sure how to do this, maybe _MOTIF_WM_HINTS?
         warn!("WindowBuilder::show_titlebar is currently unimplemented for X11 backend.");
+        self
     }
 
-    pub fn set_transparent(&mut self, transparent: bool) {
+    pub fn set_transparent(mut self, transparent: bool) -> Self {
         self.transparent = transparent;
+        self
     }
 
-    pub fn set_position(&mut self, position: Point) {
+    pub fn set_position(mut self, position: Point) -> Self {
         self.position = Some(position);
+        self
     }
 
-    pub fn set_level(&mut self, level: WindowLevel) {
+    pub fn set_level(mut self, level: WindowLevel) -> Self {
         self.level = level;
+        self
     }
 
-    pub fn set_window_state(&mut self, state: window::WindowState) {
+    pub fn set_window_state(mut self, state: window::WindowState) -> Self {
         self.state = Some(state);
+        self
     }
 
-    pub fn set_title<S: Into<String>>(&mut self, title: S) {
+    pub fn set_title<S: Into<String>>(mut self, title: S) -> Self {
         self.title = title.into();
+        self
     }
 
-    pub fn set_menu(&mut self, _menu: Menu) {
+    pub fn set_menu(self, _menu: Menu) -> Self {
         // TODO(x11/menus): implement WindowBuilder::set_menu (currently a no-op)
+        warn!("WindowBuilder::set_menu is currently unimplemented for X11 backend.");
+        self
     }
 
     // TODO(x11/menus): make menus if requested

--- a/src/window.rs
+++ b/src/window.rs
@@ -454,8 +454,8 @@ impl WindowBuilder {
     /// Set the [`WinHandler`] for this window.
     ///
     /// This is the object that will receive callbacks from this window.
-    pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
-        self.0 = self.0.set_handler(handler);
+    pub fn handler(mut self, handler: Box<dyn WinHandler>) -> Self {
+        self.0 = self.0.handler(handler);
         self
     }
 
@@ -469,8 +469,8 @@ impl WindowBuilder {
     /// [`WinHandler::size`] method.
     ///
     /// [display points]: crate::Scale
-    pub fn set_size(mut self, size: Size) -> Self {
-        self.0 = self.0.set_size(size);
+    pub fn size(mut self, size: Size) -> Self {
+        self.0 = self.0.size(size);
         self
     }
 
@@ -482,8 +482,8 @@ impl WindowBuilder {
     /// The platform might increase the size a tiny bit due to DPI.
     ///
     /// [display points]: crate::Scale
-    pub fn set_min_size(mut self, size: Size) -> Self {
-        self.0 = self.0.set_min_size(size);
+    pub fn min_size(mut self, size: Size) -> Self {
+        self.0 = self.0.min_size(size);
         self
     }
 
@@ -500,43 +500,43 @@ impl WindowBuilder {
     }
 
     /// Set whether the window background should be transparent
-    pub fn set_transparent(mut self, transparent: bool) -> Self {
-        self.0 = self.0.set_transparent(transparent);
+    pub fn transparent(mut self, transparent: bool) -> Self {
+        self.0 = self.0.transparent(transparent);
         self
     }
 
     /// Sets the initial window position in display points.
     /// For windows with a parent, the position is relative to the parent.
     /// For windows without a parent, it is relative to the origin of the virtual screen.
-    /// See also [set_level]
+    /// See also [level]
     ///
-    /// [set_level]: crate::WindowBuilder::set_level
-    pub fn set_position(mut self, position: Point) -> Self {
-        self.0 = self.0.set_position(position);
+    /// [level]: crate::WindowBuilder::level
+    pub fn position(mut self, position: Point) -> Self {
+        self.0 = self.0.position(position);
         self
     }
 
     /// Sets the initial [`WindowLevel`].
-    pub fn set_level(mut self, level: WindowLevel) -> Self {
-        self.0 = self.0.set_level(level);
+    pub fn level(mut self, level: WindowLevel) -> Self {
+        self.0 = self.0.level(level);
         self
     }
 
     /// Set the window's initial title.
-    pub fn set_title(mut self, title: impl Into<String>) -> Self {
-        self.0 = self.0.set_title(title);
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.0 = self.0.title(title);
         self
     }
 
     /// Set the window's menu.
-    pub fn set_menu(mut self, menu: Menu) -> Self {
-        self.0 = self.0.set_menu(menu.into_inner());
+    pub fn menu(mut self, menu: Menu) -> Self {
+        self.0 = self.0.menu(menu.into_inner());
         self
     }
 
     /// Sets the initial state of the window.
-    pub fn set_window_state(mut self, state: WindowState) -> Self {
-        self.0 = self.0.set_window_state(state);
+    pub fn window_state(mut self, state: WindowState) -> Self {
+        self.0 = self.0.window_state(state);
         self
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -454,8 +454,9 @@ impl WindowBuilder {
     /// Set the [`WinHandler`] for this window.
     ///
     /// This is the object that will receive callbacks from this window.
-    pub fn set_handler(&mut self, handler: Box<dyn WinHandler>) {
-        self.0.set_handler(handler)
+    pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
+        self.0.set_handler(handler);
+        self
     }
 
     /// Set the window's initial drawing area size in [display points].
@@ -468,8 +469,9 @@ impl WindowBuilder {
     /// [`WinHandler::size`] method.
     ///
     /// [display points]: crate::Scale
-    pub fn set_size(&mut self, size: Size) {
-        self.0.set_size(size)
+    pub fn set_size(mut self, size: Size) -> Self {
+        self.0.set_size(size);
+        self
     }
 
     /// Set the window's minimum drawing area size in [display points].
@@ -480,23 +482,27 @@ impl WindowBuilder {
     /// The platform might increase the size a tiny bit due to DPI.
     ///
     /// [display points]: crate::Scale
-    pub fn set_min_size(&mut self, size: Size) {
-        self.0.set_min_size(size)
+    pub fn set_min_size(mut self, size: Size) -> Self {
+        self.0.set_min_size(size);
+        self
     }
 
     /// Set whether the window should be resizable.
-    pub fn resizable(&mut self, resizable: bool) {
-        self.0.resizable(resizable)
+    pub fn resizable(mut self, resizable: bool) -> Self {
+        self.0.resizable(resizable);
+        self
     }
 
     /// Set whether the window should have a titlebar and decorations.
-    pub fn show_titlebar(&mut self, show_titlebar: bool) {
-        self.0.show_titlebar(show_titlebar)
+    pub fn show_titlebar(mut self, show_titlebar: bool) -> Self {
+        self.0.show_titlebar(show_titlebar);
+        self
     }
 
     /// Set whether the window background should be transparent
-    pub fn set_transparent(&mut self, transparent: bool) {
-        self.0.set_transparent(transparent)
+    pub fn set_transparent(mut self, transparent: bool) -> Self {
+        self.0.set_transparent(transparent);
+        self
     }
 
     /// Sets the initial window position in display points.
@@ -505,28 +511,33 @@ impl WindowBuilder {
     /// See also [set_level]
     ///
     /// [set_level]: crate::WindowBuilder::set_level
-    pub fn set_position(&mut self, position: Point) {
+    pub fn set_position(mut self, position: Point) -> Self {
         self.0.set_position(position);
+        self
     }
 
     /// Sets the initial [`WindowLevel`].
-    pub fn set_level(&mut self, level: WindowLevel) {
+    pub fn set_level(mut self, level: WindowLevel) -> Self {
         self.0.set_level(level);
+        self
     }
 
     /// Set the window's initial title.
-    pub fn set_title(&mut self, title: impl Into<String>) {
-        self.0.set_title(title)
+    pub fn set_title(mut self, title: impl Into<String>) -> Self {
+        self.0.set_title(title);
+        self
     }
 
     /// Set the window's menu.
-    pub fn set_menu(&mut self, menu: Menu) {
-        self.0.set_menu(menu.into_inner())
+    pub fn set_menu(mut self, menu: Menu) -> Self {
+        self.0.set_menu(menu.into_inner());
+        self
     }
 
     /// Sets the initial state of the window.
-    pub fn set_window_state(&mut self, state: WindowState) {
+    pub fn set_window_state(mut self, state: WindowState) -> Self {
         self.0.set_window_state(state);
+        self
     }
 
     /// Attempt to construct the platform window.

--- a/src/window.rs
+++ b/src/window.rs
@@ -455,7 +455,7 @@ impl WindowBuilder {
     ///
     /// This is the object that will receive callbacks from this window.
     pub fn set_handler(mut self, handler: Box<dyn WinHandler>) -> Self {
-        self.0.set_handler(handler);
+        self.0 = self.0.set_handler(handler);
         self
     }
 
@@ -470,7 +470,7 @@ impl WindowBuilder {
     ///
     /// [display points]: crate::Scale
     pub fn set_size(mut self, size: Size) -> Self {
-        self.0.set_size(size);
+        self.0 = self.0.set_size(size);
         self
     }
 
@@ -483,25 +483,25 @@ impl WindowBuilder {
     ///
     /// [display points]: crate::Scale
     pub fn set_min_size(mut self, size: Size) -> Self {
-        self.0.set_min_size(size);
+        self.0 = self.0.set_min_size(size);
         self
     }
 
     /// Set whether the window should be resizable.
     pub fn resizable(mut self, resizable: bool) -> Self {
-        self.0.resizable(resizable);
+        self.0 = self.0.resizable(resizable);
         self
     }
 
     /// Set whether the window should have a titlebar and decorations.
     pub fn show_titlebar(mut self, show_titlebar: bool) -> Self {
-        self.0.show_titlebar(show_titlebar);
+        self.0 = self.0.show_titlebar(show_titlebar);
         self
     }
 
     /// Set whether the window background should be transparent
     pub fn set_transparent(mut self, transparent: bool) -> Self {
-        self.0.set_transparent(transparent);
+        self.0 = self.0.set_transparent(transparent);
         self
     }
 
@@ -512,31 +512,31 @@ impl WindowBuilder {
     ///
     /// [set_level]: crate::WindowBuilder::set_level
     pub fn set_position(mut self, position: Point) -> Self {
-        self.0.set_position(position);
+        self.0 = self.0.set_position(position);
         self
     }
 
     /// Sets the initial [`WindowLevel`].
     pub fn set_level(mut self, level: WindowLevel) -> Self {
-        self.0.set_level(level);
+        self.0 = self.0.set_level(level);
         self
     }
 
     /// Set the window's initial title.
     pub fn set_title(mut self, title: impl Into<String>) -> Self {
-        self.0.set_title(title);
+        self.0 = self.0.set_title(title);
         self
     }
 
     /// Set the window's menu.
     pub fn set_menu(mut self, menu: Menu) -> Self {
-        self.0.set_menu(menu.into_inner());
+        self.0 = self.0.set_menu(menu.into_inner());
         self
     }
 
     /// Sets the initial state of the window.
     pub fn set_window_state(mut self, state: WindowState) -> Self {
-        self.0.set_window_state(state);
+        self.0 = self.0.set_window_state(state);
         self
     }
 


### PR DESCRIPTION
Following up on [the discussion in Zulip](https://xi.zulipchat.com/#narrow/stream/351333-glazier/topic/Builder.20pattern.20in.20WindowBuilder), this PR changes `WindowBuilder` methods `&mut self` argument to `mut self` and return value to `Self`, so that methods could be chained. Besides that, I took a liberty to also remove `set_` prefix from `WindowBuilder` methods, and also changed `WindowBuilder` for all backends to keep it consistent with the top-level one. Let me know if any of that is undesired, I'll revert.

I've tested all examples except `accesskit` on X11 backend, and tested their compilation on Wayland and GTK backends (I have issues running on these backends same as on `main`: GTK segfaults, Wayland has transparent window). I hope the CI will make sure others compile?

