### PR TITLE
Only compile bindgen on platforms actually generating bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ parley = { git = "https://github.com/dfrg/parley", rev = "e4276b4d1001a050c07121
 pollster = "0.2.5"
 wgpu = "0.15.0"
 
-[build-dependencies]
+[target.'cfg(any(target_os = "freebsd", target_os="linux", target_os="openbsd"))'.build-dependencies]
 bindgen = { version = "0.60.1", optional = true }
 pkg-config = { version = "0.3.25", optional = true }
 

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,17 @@
-#[cfg(not(any(feature = "x11", feature = "wayland")))]
+#[cfg(not(all(
+    any(feature = "x11", feature = "wayland"),
+    any(target_os = "freebsd", target_os = "linux", target_os = "openbsd")
+)))]
 fn main() {}
 
-#[cfg(any(feature = "x11", feature = "wayland"))]
+#[cfg(all(
+    any(feature = "x11", feature = "wayland"),
+    any(target_os = "freebsd", target_os = "linux", target_os = "openbsd")
+))]
 fn main() {
     use pkg_config::probe_library;
     use std::env;
     use std::path::PathBuf;
-
-    if env::var("CARGO_CFG_TARGET_OS").unwrap() != "freebsd"
-        && env::var("CARGO_CFG_TARGET_OS").unwrap() != "linux"
-        && env::var("CARGO_CFG_TARGET_OS").unwrap() != "openbsd"
-    {
-        return;
-    }
 
     let xkbcommon = probe_library("xkbcommon").unwrap();
 


### PR DESCRIPTION
While playing with xilem I noticed long download and compile times. One cause is that glazier enables x11 by default and xilem does so too. Currently, bindgen will be compiled even on platforms not needing bindings, which adds at least 10 seconds to the build times.