### PR TITLE
Handle keyboard input more robustly on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ## Rust
-target/
+/target
 Cargo.lock
 
 ## Intellij Idea

--- a/src/backend/shared/xkb/keycodes.rs
+++ b/src/backend/shared/xkb/keycodes.rs
@@ -8,7 +8,6 @@ use super::xkbcommon_sys::*;
 pub fn map_key(keysym: u32) -> Key {
     use Key::*;
     match keysym {
-        XKB_KEY_v => Key::Character("v".to_string()),
         XKB_KEY_BackSpace => Backspace,
         XKB_KEY_Tab | XKB_KEY_KP_Tab | XKB_KEY_ISO_Left_Tab => Tab,
         XKB_KEY_Clear | XKB_KEY_KP_Begin | XKB_KEY_XF86Clear => Clear,

--- a/src/backend/shared/xkb/mod.rs
+++ b/src/backend/shared/xkb/mod.rs
@@ -23,14 +23,13 @@ use crate::{
 use keyboard_types::{Code, Key};
 use std::convert::TryFrom;
 use std::os::raw::c_char;
-use std::ptr;
 use xkbcommon_sys::*;
 
 #[cfg(feature = "x11")]
 use x11rb::xcb_ffi::XCBConnection;
 
 #[cfg(feature = "x11")]
-pub struct DeviceId(std::os::raw::c_int);
+pub struct DeviceId(pub std::os::raw::c_int);
 
 /// A global xkb context object.
 ///
@@ -61,7 +60,7 @@ impl Context {
     }
 
     #[cfg(feature = "x11")]
-    pub fn keymap_from_device(&self, conn: &XCBConnection, device: DeviceId) -> Option<Keymap> {
+    pub fn keymap_from_device(&self, conn: &XCBConnection, device: &DeviceId) -> Option<Keymap> {
         let key_map = unsafe {
             xkb_x11_keymap_new_from_device(
                 self.0,
@@ -76,6 +75,34 @@ impl Context {
         Some(Keymap(key_map))
     }
 
+    #[cfg(feature = "x11")]
+    pub fn state_from_keymap(
+        &self,
+        keymap: &Keymap,
+        conn: &XCBConnection,
+        device: &DeviceId,
+    ) -> Option<State> {
+        let state = unsafe {
+            xkb_x11_state_new_from_device(
+                keymap.0,
+                conn.get_raw_xcb_connection() as *mut xcb_connection_t,
+                device.0,
+            )
+        };
+        if state.is_null() {
+            return None;
+        }
+        Some(State::new(keymap, state))
+    }
+
+    #[cfg(feature = "wayland")]
+    pub fn state_from_keymap(&self, keymap: &Keymap) -> Option<State> {
+        let state = unsafe { xkb_state_new(keymap.0) };
+        if state.is_null() {
+            return None;
+        }
+        Some(State::new(keymap, state))
+    }
     /// Create a keymap from some given data.
     ///
     /// Uses `xkb_keymap_new_from_buffer` under the hood.
@@ -136,12 +163,6 @@ impl Drop for Context {
 
 pub struct Keymap(*mut xkb_keymap);
 
-impl Keymap {
-    pub fn state(&self) -> State {
-        State::new(self)
-    }
-}
-
 impl Clone for Keymap {
     fn clone(&self) -> Self {
         Self(unsafe { xkb_keymap_ref(self.0) })
@@ -159,6 +180,7 @@ impl Drop for Keymap {
 pub struct State {
     state: *mut xkb_state,
     mods: ModsIndices,
+    pub keyboard_state: ActiveModifiers,
 }
 
 #[derive(Clone, Copy)]
@@ -171,10 +193,19 @@ pub struct ModsIndices {
     num_lock: xkb_mod_index_t,
 }
 
+#[derive(Clone, Copy)]
+pub struct ActiveModifiers {
+    pub base_mods: xkb_mod_mask_t,
+    pub latched_mods: xkb_mod_mask_t,
+    pub locked_mods: xkb_mod_mask_t,
+    pub base_layout: xkb_layout_index_t,
+    pub latched_layout: xkb_layout_index_t,
+    pub locked_layout: xkb_layout_index_t,
+}
+
 impl State {
-    pub fn new(keymap: &Keymap) -> Self {
+    pub fn new(keymap: &Keymap, state: *mut xkb_state) -> Self {
         let keymap = keymap.0;
-        let state = unsafe { xkb_state_new(keymap) };
         let mod_idx = |str: &'static [u8]| unsafe {
             xkb_keymap_mod_get_index(keymap, str.as_ptr() as *mut c_char)
         };
@@ -188,7 +219,30 @@ impl State {
                 caps_lock: mod_idx(XKB_MOD_NAME_CAPS),
                 num_lock: mod_idx(XKB_MOD_NAME_NUM),
             },
+            keyboard_state: ActiveModifiers {
+                base_mods: 0,
+                latched_mods: 0,
+                locked_mods: 0,
+                base_layout: 0,
+                latched_layout: 0,
+                locked_layout: 0,
+            },
         }
+    }
+
+    pub fn update_xkb_state(&mut self) {
+        let mods = self.keyboard_state;
+        unsafe {
+            xkb_state_update_mask(
+                self.state,
+                mods.base_mods,
+                mods.latched_mods,
+                mods.locked_mods,
+                mods.base_layout,
+                mods.latched_layout,
+                mods.locked_layout,
+            )
+        };
     }
 
     pub fn key_event(&mut self, scancode: u32, state: KeyState, repeat: bool) -> KeyEvent {
@@ -205,18 +259,7 @@ impl State {
         let mut mods = Modifiers::empty();
         // Update xkb's state (e.g. return capitals if we've pressed shift)
         unsafe {
-            if !repeat {
-                xkb_state_update_key(
-                    self.state,
-                    scancode,
-                    match state {
-                        KeyState::Down => XKB_KEY_DOWN,
-                        KeyState::Up => XKB_KEY_UP,
-                    },
-                );
-            }
             // compiler will unroll this loop
-            // FIXME(msrv): remove .iter().cloned() when msrv is >= 1.53
             for (idx, mod_) in [
                 (self.mods.control, Modifiers::CONTROL),
                 (self.mods.shift, Modifiers::SHIFT),
@@ -224,10 +267,7 @@ impl State {
                 (self.mods.alt, Modifiers::ALT),
                 (self.mods.caps_lock, Modifiers::CAPS_LOCK),
                 (self.mods.num_lock, Modifiers::NUM_LOCK),
-            ]
-            .iter()
-            .cloned()
-            {
+            ] {
                 if xkb_state_mod_index_is_active(self.state, idx, XKB_STATE_MODS_EFFECTIVE) != 0 {
                     mods |= mod_;
                 }
@@ -245,9 +285,10 @@ impl State {
     }
 
     fn get_logical_key(&mut self, scancode: u32) -> Key {
-        let mut key = keycodes::map_key(self.key_get_one_sym(scancode));
+        let keysym = self.key_get_one_sym(scancode);
+        let mut key = keycodes::map_key(keysym);
         if matches!(key, Key::Unidentified) {
-            if let Some(s) = self.key_get_utf8(scancode) {
+            if let Some(s) = self.key_get_utf8(keysym) {
                 key = Key::Character(s);
             }
         }
@@ -260,23 +301,20 @@ impl State {
 
     /// Get the string representation of a key.
     // TODO `keyboard_types` forces us to return a String, but it would be nicer if we could stay
-    // on the stack, especially since we expect most results to be pretty small.
-    fn key_get_utf8(&mut self, scancode: u32) -> Option<String> {
-        unsafe {
-            // First get the size we will need
-            let len = xkb_state_key_get_utf8(self.state, scancode, ptr::null_mut(), 0);
-            if len == 0 {
-                return None;
-            }
-            // add 1 because we will get a null-terminated string.
-            let len = usize::try_from(len).unwrap() + 1;
-            let mut buf: Vec<u8> = Vec::new();
-            buf.resize(len, 0);
-            xkb_state_key_get_utf8(self.state, scancode, buf.as_mut_ptr() as *mut c_char, len);
-            assert!(buf[buf.len() - 1] == 0);
-            buf.pop();
-            Some(String::from_utf8(buf).unwrap())
+    // on the stack, especially since we know all results will only contain 1 unicode codepoint
+    fn key_get_utf8(&mut self, keysym: u32) -> Option<String> {
+        // We convert the symbol to text here rather than using X11's interpretation of
+        // because (experimentally) [UI Events Keyboard Events](https://www.w3.org/TR/uievents-key/#key-attribute-value)
+        // use the symbol rather than the x11 string (which includes the ctrl KeySym transformation)
+        // If we used the KeySym transformation, it would not be possible to use keyboard shortcuts containing the
+        // control key, for example
+        let chr = unsafe { xkb_keysym_to_utf32(keysym) };
+        if chr == 0 {
+            // There is no unicode representation of this symbol
+            return None;
         }
+        let chr = char::from_u32(chr).expect("xkb should give valid UTF-32 char");
+        Some(String::from(chr))
     }
 }
 
@@ -285,6 +323,7 @@ impl Clone for State {
         Self {
             state: unsafe { xkb_state_ref(self.state) },
             mods: self.mods,
+            keyboard_state: self.keyboard_state,
         }
     }
 }

--- a/src/backend/wayland/keyboard.rs
+++ b/src/backend/wayland/keyboard.rs
@@ -197,14 +197,15 @@ impl Keyboard {
             } => {
                 let mut state = self.xkb_state.borrow_mut();
                 let state = state.as_mut().unwrap();
-                state.keyboard_state.base_mods = mods_depressed;
-                state.keyboard_state.latched_mods = mods_latched;
-                state.keyboard_state.locked_mods = mods_locked;
-                state.keyboard_state.base_layout = group;
-                // See https://gitlab.gnome.org/GNOME/gtk/-/blob/cffa45d5ff97b3b6107bb9d563a84a529014342a/gdk/wayland/gdkdevice-wayland.c#L2163-2177
-                state.keyboard_state.latched_layout = 0;
-                state.keyboard_state.locked_layout = 0;
-                state.update_xkb_state();
+                state.update_xkb_state(xkb::ActiveModifiers {
+                    base_mods: mods_depressed,
+                    latched_mods: mods_latched,
+                    locked_mods: mods_locked,
+                    base_layout: group,
+                    // See https://gitlab.gnome.org/GNOME/gtk/-/blob/cffa45d5ff97b3b6107bb9d563a84a529014342a/gdk/wayland/gdkdevice-wayland.c#L2163-2177
+                    latched_layout: 0,
+                    locked_layout: 0,
+                });
             }
             wl_keyboard::Event::RepeatInfo { rate, delay } => {
                 tracing::trace!("keyboard repeat info received {:?} {:?}", rate, delay);

--- a/src/backend/wayland/keyboard.rs
+++ b/src/backend/wayland/keyboard.rs
@@ -154,10 +154,10 @@ impl Keyboard {
 
                 // keymap data is '\0' terminated.
                 let keymap = self.xkb_context.keymap_from_slice(&keymap_data);
-                let keymapstate = keymap.state();
+                let keymapstate = self.xkb_context.state_from_keymap(&keymap);
 
                 self.xkb_keymap.replace(Some(keymap));
-                self.xkb_state.replace(Some(keymapstate));
+                self.xkb_state.replace(keymapstate);
             }
             wl_keyboard::Event::Enter { .. } => {
                 self.focused(true);
@@ -188,8 +188,23 @@ impl Keyboard {
                     queue: keyqueue,
                 })
             }
-            wl_keyboard::Event::Modifiers { .. } => {
-                self.xkb_mods.replace(event_to_mods(event));
+            wl_keyboard::Event::Modifiers {
+                mods_depressed,
+                mods_latched,
+                mods_locked,
+                group,
+                ..
+            } => {
+                let mut state = self.xkb_state.borrow_mut();
+                let state = state.as_mut().unwrap();
+                state.keyboard_state.base_mods = mods_depressed;
+                state.keyboard_state.latched_mods = mods_latched;
+                state.keyboard_state.locked_mods = mods_locked;
+                state.keyboard_state.base_layout = group;
+                // See https://gitlab.gnome.org/GNOME/gtk/-/blob/cffa45d5ff97b3b6107bb9d563a84a529014342a/gdk/wayland/gdkdevice-wayland.c#L2163-2177
+                state.keyboard_state.latched_layout = 0;
+                state.keyboard_state.locked_layout = 0;
+                state.update_xkb_state();
             }
             wl_keyboard::Event::RepeatInfo { rate, delay } => {
                 tracing::trace!("keyboard repeat info received {:?} {:?}", rate, delay);
@@ -278,45 +293,6 @@ impl Default for State {
         });
 
         state
-    }
-}
-
-struct ModMap(u32, Modifiers);
-
-impl ModMap {
-    fn merge(self, m: Modifiers, mods: u32, locked: u32) -> Modifiers {
-        if self.0 & mods == 0 && self.0 & locked == 0 {
-            return m;
-        }
-
-        m | self.1
-    }
-}
-
-const MOD_SHIFT: ModMap = ModMap(1, Modifiers::SHIFT);
-const MOD_CAP_LOCK: ModMap = ModMap(2, Modifiers::CAPS_LOCK);
-const MOD_CTRL: ModMap = ModMap(4, Modifiers::CONTROL);
-const MOD_ALT: ModMap = ModMap(8, Modifiers::ALT);
-const MOD_NUM_LOCK: ModMap = ModMap(16, Modifiers::NUM_LOCK);
-const MOD_META: ModMap = ModMap(64, Modifiers::META);
-
-pub fn event_to_mods(event: wl_keyboard::Event) -> Modifiers {
-    match event {
-        wl_keyboard::Event::Modifiers {
-            mods_depressed,
-            mods_locked,
-            ..
-        } => {
-            let mods = Modifiers::empty();
-            let mods = MOD_SHIFT.merge(mods, mods_depressed, mods_locked);
-            let mods = MOD_CAP_LOCK.merge(mods, mods_depressed, mods_locked);
-            let mods = MOD_CTRL.merge(mods, mods_depressed, mods_locked);
-            let mods = MOD_ALT.merge(mods, mods_depressed, mods_locked);
-            let mods = MOD_NUM_LOCK.merge(mods, mods_depressed, mods_locked);
-
-            MOD_META.merge(mods, mods_depressed, mods_locked)
-        }
-        _ => Modifiers::empty(),
     }
 }
 

--- a/src/backend/x11/application.rs
+++ b/src/backend/x11/application.rs
@@ -25,6 +25,7 @@ use anyhow::{anyhow, Context, Error};
 use x11rb::connection::{Connection, RequestConnection};
 use x11rb::protocol::render::{self, ConnectionExt as _, Pictformat};
 use x11rb::protocol::xinput::ChangeReason;
+use x11rb::protocol::xkb::{EventType, MapPart, SelectEventsAux};
 use x11rb::protocol::xproto::{
     self, ConnectionExt as _, CreateWindowAux, EventMask, Timestamp, Visualtype, WindowClass,
 };
@@ -299,10 +300,22 @@ impl AppInner {
             .context("get core keyboard device id")?;
 
         let keymap = xkb_context
-            .keymap_from_device(&connection, device_id)
+            .keymap_from_device(&connection, &device_id)
             .context("key map from device")?;
 
-        let xkb_state = keymap.state();
+        connection
+            .xkb_select_events(
+                device_id.0 as u16,
+                EventType::default(),
+                EventType::STATE_NOTIFY,
+                MapPart::default(),
+                MapPart::default(),
+                &SelectEventsAux::default(),
+            )
+            .context("Subscribing to State notify events")?;
+        let xkb_state = xkb_context
+            .state_from_keymap(&keymap, &connection, &device_id)
+            .context("State from keymap and device")?;
         let window_id = AppInner::create_event_window(&connection, screen_num)?;
         let state = RefCell::new(State {
             quitting: false,
@@ -577,6 +590,18 @@ impl AppInner {
                 );
 
                 w.handle_key_event(key_event);
+            }
+            Event::XkbStateNotify(ev) => {
+                let mut state = borrow_mut!(self.state)?;
+                let mods = &mut state.xkb_state.keyboard_state;
+                mods.base_mods = ev.base_mods.into();
+                mods.latched_mods = ev.latched_mods.into();
+                mods.locked_mods = ev.locked_mods.into();
+
+                mods.base_layout = ev.base_group as u32;
+                mods.latched_layout = ev.latched_group as u32;
+                mods.locked_layout = ev.locked_group.into();
+                state.xkb_state.update_xkb_state();
             }
             Event::KeyRelease(ev) => {
                 let w = self

--- a/src/backend/x11/application.rs
+++ b/src/backend/x11/application.rs
@@ -593,15 +593,14 @@ impl AppInner {
             }
             Event::XkbStateNotify(ev) => {
                 let mut state = borrow_mut!(self.state)?;
-                let mods = &mut state.xkb_state.keyboard_state;
-                mods.base_mods = ev.base_mods.into();
-                mods.latched_mods = ev.latched_mods.into();
-                mods.locked_mods = ev.locked_mods.into();
-
-                mods.base_layout = ev.base_group as u32;
-                mods.latched_layout = ev.latched_group as u32;
-                mods.locked_layout = ev.locked_group.into();
-                state.xkb_state.update_xkb_state();
+                state.xkb_state.update_xkb_state(xkb::ActiveModifiers {
+                    base_mods: ev.base_mods.into(),
+                    latched_mods: ev.latched_mods.into(),
+                    locked_mods: ev.locked_mods.into(),
+                    base_layout: ev.base_group as u32,
+                    latched_layout: ev.latched_group as u32,
+                    locked_layout: ev.locked_group.into(),
+                });
             }
             Event::KeyRelease(ev) => {
                 let w = self


### PR DESCRIPTION
This addresses the issue being ran into in https://github.com/linebender/druid/pull/2057 and in [#glazier > Keyboard Shortcuts](https://xi.zulipchat.com/#narrow/stream/351333-glazier/topic/Keyboard.20shortcuts).

This allows keyboard shortcuts to be used properly, at least on the x11 backend. I can't get the wayland backend to run on my machine - it instantly segfaults in wgpu-triangle, and displays nothing in edit-text.