### PR TITLE
Re-export `AppHandle` from the crate root.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ mod window;
 pub mod platform;
 pub mod text;
 
-pub use application::{AppHandler, Application};
+pub use application::{AppHandler, Application, AppHandle};
 pub use clipboard::{Clipboard, ClipboardFormat, FormatId};
 pub use common_util::Counter;
 pub use dialog::{FileDialogOptions, FileInfo, FileSpec};

--- a/src/window.rs
+++ b/src/window.rs
@@ -106,7 +106,7 @@ impl IdleHandle {
 
     /// Request a callback from the runloop. Your `WinHander::idle` method will
     /// be called with the `token` that was passed in.
-    pub fn schedule_idle(&mut self, token: IdleToken) {
+    pub fn schedule_idle(&self, token: IdleToken) {
         self.0.add_idle_token(token)
     }
 }


### PR DESCRIPTION
Previously, the type name was inaccessible and could not be used as e.g. a field in a struct.