### PR TITLE
Re-export `AppHandle` from the crate root.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ mod window;
 pub mod platform;
 pub mod text;
 
-pub use application::{AppHandler, Application, AppHandle};
+pub use application::{AppHandle, AppHandler, Application};
 pub use clipboard::{Clipboard, ClipboardFormat, FormatId};
 pub use common_util::Counter;
 pub use dialog::{FileDialogOptions, FileInfo, FileSpec};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ mod window;
 pub mod platform;
 pub mod text;
 
-pub use application::{AppHandler, Application};
+pub use application::{AppHandler, Application, AppHandle};
 pub use clipboard::{Clipboard, ClipboardFormat, FormatId};
 pub use common_util::Counter;
 pub use dialog::{FileDialogOptions, FileInfo, FileSpec};


### PR DESCRIPTION
Previously, the type name was inaccessible and could not be used as e.g. a field in a struct.
