### PR TITLE
Fullscreen support

### DIFF
--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,0 +1,188 @@
+use glazier::{Application, KeyEvent, Region, Scalable, WinHandler, WindowHandle};
+use keyboard_types::Key;
+use parley::{FontContext, Layout};
+use std::any::Any;
+use vello::util::{RenderContext, RenderSurface};
+use vello::Renderer;
+use vello::{
+    glyph::{
+        pinot::{types::Tag, FontRef},
+        GlyphContext,
+    },
+    kurbo::{Affine, Point, Rect},
+    peniko::{Brush, Color, Fill},
+    Scene, SceneBuilder,
+};
+
+fn main() {
+    let app = Application::new().unwrap();
+    let window = glazier::WindowBuilder::new(app.clone())
+        .size((640., 480.).into())
+        .handler(Box::new(WindowState::new()))
+        .build()
+        .unwrap();
+    window.show();
+    app.run(None);
+}
+
+struct WindowState {
+    handle: WindowHandle,
+    renderer: Option<Renderer>,
+    render: RenderContext,
+    surface: Option<RenderSurface>,
+    scene: Scene,
+    font_context: FontContext,
+    fullscreen: bool,
+}
+
+impl WindowState {
+    pub fn new() -> Self {
+        let render = RenderContext::new().unwrap();
+        Self {
+            handle: Default::default(),
+            surface: None,
+            renderer: None,
+            render,
+            scene: Default::default(),
+            font_context: FontContext::new(),
+            fullscreen: false,
+        }
+    }
+
+    fn schedule_render(&self) {
+        self.handle.invalidate();
+    }
+
+    fn surface_size(&self) -> (u32, u32) {
+        let handle = &self.handle;
+        let scale = handle.get_scale().unwrap_or_default();
+        let insets = handle.content_insets().to_px(scale);
+        let mut size = handle.get_size().to_px(scale);
+        size.width -= insets.x_value();
+        size.height -= insets.y_value();
+        (size.width as u32, size.height as u32)
+    }
+
+    fn render(&mut self) {
+        let (width, height) = self.surface_size();
+        if self.surface.is_none() {
+            self.surface = Some(pollster::block_on(self.render.create_surface(
+                &self.handle,
+                width,
+                height,
+            )));
+        }
+
+        let mut sb = SceneBuilder::for_scene(&mut self.scene);
+        let rect = Rect::from_origin_size(Point::new(0.0, 0.0), (width.into(), height.into()));
+        sb.fill(
+            Fill::NonZero,
+            Affine::IDENTITY,
+            &Brush::Solid(Color::WHITE_SMOKE),
+            None,
+            &rect,
+        );
+
+        let mut lcx = parley::LayoutContext::new();
+        let mut layout_builder =
+            lcx.ranged_builder(&mut self.font_context, "Press f to toggle fullscreen", 1.0);
+        let mut layout = layout_builder.build();
+        layout.break_all_lines(None, parley::layout::Alignment::Start);
+        render_text(&mut sb, Affine::IDENTITY, &layout);
+
+        if let Some(surface) = self.surface.as_mut() {
+            if surface.config.width != width || surface.config.height != height {
+                self.render.resize_surface(surface, width, height);
+            }
+            let surface_texture = surface.surface.get_current_texture().unwrap();
+            let dev_id = surface.dev_id;
+            let device = &self.render.devices[dev_id].device;
+            let queue = &self.render.devices[dev_id].queue;
+            self.renderer
+                .get_or_insert_with(|| Renderer::new(device).unwrap())
+                .render_to_surface(device, queue, &self.scene, &surface_texture, width, height)
+                .unwrap();
+            surface_texture.present();
+        }
+    }
+}
+
+impl WinHandler for WindowState {
+    fn connect(&mut self, handle: &WindowHandle) {
+        self.handle = handle.clone();
+        self.schedule_render();
+    }
+
+    fn prepare_paint(&mut self) {}
+
+    fn paint(&mut self, _: &Region) {
+        self.render();
+        self.schedule_render();
+    }
+
+    fn key_up(&mut self, event: KeyEvent) {
+        if event.key == Key::Character("f".into()) {
+            self.fullscreen ^= true;
+            self.handle.set_fullscreen(self.fullscreen);
+        }
+    }
+
+    fn request_close(&mut self) {
+        self.handle.close();
+    }
+
+    fn destroy(&mut self) {
+        Application::global().quit()
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ParleyBrush(pub Brush);
+
+impl Default for ParleyBrush {
+    fn default() -> ParleyBrush {
+        ParleyBrush(Brush::Solid(Color::rgb8(0, 0, 0)))
+    }
+}
+
+impl PartialEq<ParleyBrush> for ParleyBrush {
+    fn eq(&self, _other: &ParleyBrush) -> bool {
+        true // FIXME
+    }
+}
+
+impl parley::style::Brush for ParleyBrush {}
+
+pub fn render_text(builder: &mut SceneBuilder, transform: Affine, layout: &Layout<ParleyBrush>) {
+    let mut gcx = GlyphContext::new();
+    for line in layout.lines() {
+        for glyph_run in line.glyph_runs() {
+            let mut x = glyph_run.offset();
+            let y = glyph_run.baseline();
+            let run = glyph_run.run();
+            let font = run.font().as_ref();
+            let font_size = run.font_size();
+            let font_ref = FontRef {
+                data: font.data,
+                offset: font.offset,
+            };
+            let style = glyph_run.style();
+            let vars: [(Tag, f32); 0] = [];
+            let mut gp = gcx.new_provider(&font_ref, None, font_size, false, vars);
+            for glyph in glyph_run.glyphs() {
+                if let Some(fragment) = gp.get(glyph.id, Some(&style.brush.0)) {
+                    let gx = x + glyph.x;
+                    let gy = y - glyph.y;
+                    let xform = Affine::translate((gx as f64, gy as f64))
+                        * Affine::scale_non_uniform(1.0, -1.0);
+                    builder.append(&fragment, Some(transform * xform));
+                }
+                x += glyph.advance;
+            }
+        }
+    }
+}

--- a/src/backend/gtk/window.rs
+++ b/src/backend/gtk/window.rs
@@ -1004,6 +1004,10 @@ impl WindowHandle {
         }
     }
 
+    pub fn set_fullscreen(&self, _fullscreen: bool) {
+        warn!("set_fullscreen unimplemented on gtk");
+    }
+
     pub fn set_position(&self, mut position: Point) {
         if let Some(state) = self.state.upgrade() {
             if let Some(parent_state) = &state.parent {
@@ -1094,6 +1098,8 @@ impl WindowHandle {
                 (Minimized, _) => state.window.iconify(),
                 (Restored, Maximized) => state.window.unmaximize(),
                 (Restored, Minimized) => state.window.deiconify(),
+                (Fullscreen, _) => (), // Fullscreen not yet supported,
+                (_, Fullscreen) => (),
                 (Restored, Restored) => (), // Unreachable
             }
         }

--- a/src/backend/mac/window.rs
+++ b/src/backend/mac/window.rs
@@ -1327,6 +1327,9 @@ impl WindowHandle {
     // TODO: Implement this
     pub fn show_titlebar(&self, _show_titlebar: bool) {}
 
+    // TODO: Implement this
+    pub fn set_fullscreen(&self, _fullscreen: bool) {}
+
     // Need to translate mac y coords, as they start from bottom left
     pub fn set_position(&self, mut position: Point) {
         // TODO: Maybe @cmyr can get this into a state where modal windows follow the parent?
@@ -1451,6 +1454,8 @@ impl WindowHandle {
                 (WindowState::Restored, WindowState::Minimized) => {
                     let () = msg_send![window, deminiaturize: self];
                 }
+                (WindowState::Fullscreen, _) => {} // Fullscreen not yet implemented
+                (_, WindowState::Fullscreen) => {}
                 (WindowState::Restored, WindowState::Restored) => {} // Can't be reached
             }
         }

--- a/src/backend/wayland/window.rs
+++ b/src/backend/wayland/window.rs
@@ -110,6 +110,10 @@ impl WindowHandle {
         tracing::warn!("show_titlebar is unimplemented on wayland");
     }
 
+    pub fn set_fullscreen(&self, _fullscreen: bool) {
+        tracing::warn!("set_fullscreen unimplemented on wayland");
+    }
+
     pub fn set_position(&self, _position: Point) {
         tracing::warn!("set_position is unimplemented on wayland");
     }

--- a/src/backend/web/window.rs
+++ b/src/backend/web/window.rs
@@ -514,6 +514,10 @@ impl WindowHandle {
         warn!("show_titlebar unimplemented for web");
     }
 
+    pub fn set_fullscreen(&self, _fullscreen: bool) {
+        warn!("WindowHandle::set_fullscreen unimplemented for web");
+    }
+
     pub fn set_position(&self, _position: Point) {
         warn!("WindowHandle::set_position unimplemented for web");
     }

--- a/src/backend/windows/window.rs
+++ b/src/backend/windows/window.rs
@@ -216,6 +216,15 @@ struct AccessKitActionHandler {
     idle_handle: IdleHandle,
 }
 
+/// Stored state to allow for restoring from fullscreen.
+#[derive(Copy, Clone)]
+struct WindowPlat {
+    maximized: bool,
+    area: RECT,
+    style: DWORD,
+    ex_style: DWORD,
+}
+
 /// This is the low level window state. All mutable contents are protected
 /// by interior mutability, so we can handle reentrant calls.
 struct WindowState {
@@ -233,6 +242,7 @@ struct WindowState {
     // For resizable borders, window can still be resized with code.
     is_resizable: Cell<bool>,
     handle_titlebar: Cell<bool>,
+    saved_plat: Cell<Option<WindowPlat>>,
     active_text_input: Cell<Option<TextFieldToken>>,
     // Is the window focusable ("activatable" in Win32 terminology)?
     // False for tooltips, to prevent stealing focus from owner window.
@@ -552,17 +562,110 @@ impl MyWndProc {
                     set_style(hwnd, resizable, self.has_titlebar());
                 }
                 DeferredOp::SetWindowState(val) => {
-                    let show = if self.handle.borrow().is_focusable() {
-                        match val {
-                            window::WindowState::Maximized => SW_MAXIMIZE,
-                            window::WindowState::Minimized => SW_MINIMIZE,
-                            window::WindowState::Restored => SW_RESTORE,
+                    if !self.handle.borrow().is_focusable() {
+                        // Tooltip or similar window
+                        unsafe {
+                            ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+                        }
+                    } else if val == window::WindowState::Fullscreen {
+                        println!("set window state: {:?}", val);
+                        // Manually set the window to fullscreen
+                        unsafe {
+                            // Save the current window state.
+                            let style = GetWindowLongA(hwnd, GWL_STYLE) as DWORD;
+                            let ex_style = GetWindowLongA(hwnd, GWL_EXSTYLE) as DWORD;
+                            let mut window_rect: RECT = mem::zeroed();
+                            if GetWindowRect(hwnd, &mut window_rect) == 0 {
+                                warn!(
+                                    "failed to get window rect: {}",
+                                    Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
+                                );
+                            };
+                            let plat = WindowPlat {
+                                maximized: style & WS_MAXIMIZE != 0,
+                                area: window_rect,
+                                style,
+                                ex_style,
+                            };
+                            self.with_window_state(|s| s.saved_plat.set(Some(plat)));
+
+                            // Retrieve the area of the current monitor
+                            let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+                            let mut monitor_info: MONITORINFO = mem::zeroed();
+                            monitor_info.cbSize = mem::size_of::<MONITORINFO>() as DWORD;
+                            if GetMonitorInfoW(monitor, &mut monitor_info) == 0 {
+                                warn!(
+                                    "failed to get monitor info: {}",
+                                    Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
+                                );
+                                return;
+                            };
+                            let monitor_area: RECT = monitor_info.rcMonitor;
+
+                            // Remove window decorations and spread across screen
+                            SetWindowLongA(
+                                hwnd,
+                                GWL_STYLE,
+                                (style & !(WS_CAPTION | WS_THICKFRAME)) as i32,
+                            );
+                            SetWindowLongA(
+                                hwnd,
+                                GWL_EXSTYLE,
+                                (ex_style
+                                    & !(WS_EX_DLGMODALFRAME
+                                        | WS_EX_WINDOWEDGE
+                                        | WS_EX_CLIENTEDGE
+                                        | WS_EX_STATICEDGE)) as i32,
+                            );
+                            SetWindowPos(
+                                hwnd,
+                                HWND_TOP,
+                                monitor_area.left,
+                                monitor_area.top,
+                                monitor_area.right,
+                                monitor_area.bottom,
+                                SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED,
+                            );
+                        }
+                    } else if val == window::WindowState::Minimized {
+                        // Minimize the window, leaving other state unchanged
+                        unsafe {
+                            ShowWindow(hwnd, SW_MINIMIZE);
                         }
                     } else {
-                        SW_SHOWNOACTIVATE
-                    };
-                    unsafe {
-                        ShowWindow(hwnd, show);
+                        // Maximize or restore the window
+                        let new_state = match val {
+                            window::WindowState::Maximized => SW_MAXIMIZE,
+                            window::WindowState::Restored => SW_RESTORE,
+                            _ => {
+                                warn!("arrived at unreachable state");
+                                return;
+                            }
+                        };
+
+                        unsafe {
+                            // If the window is fullscreen, try to restore it to a saved state
+                            if (GetWindowLongPtrW(hwnd, GWL_STYLE) as DWORD & !WS_CAPTION) != 0 {
+                                if let Some(p) = self.with_window_state(|s| s.saved_plat.take()) {
+                                    let area = p.area;
+                                    SetWindowLongA(hwnd, GWL_STYLE, p.style as i32);
+                                    SetWindowLongA(hwnd, GWL_EXSTYLE, p.ex_style as i32);
+                                    SetWindowPos(
+                                        hwnd,
+                                        HWND_TOPMOST,
+                                        area.left,
+                                        area.top,
+                                        area.right - area.left,
+                                        area.bottom - area.top,
+                                        SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED,
+                                    );
+                                    return;
+                                }
+                            }
+
+                            // Otherwise, or if retrieving the saved state failed, set the window state normally
+                            ShowWindow(hwnd, new_state);
+                        }
                     }
                 }
                 DeferredOp::SaveAs(options, token) => {
@@ -1373,6 +1476,7 @@ impl WindowBuilder {
                 is_resizable: Cell::new(self.resizable),
                 is_transparent: Cell::new(self.transparent),
                 handle_titlebar: Cell::new(false),
+                saved_plat: Cell::new(None),
                 active_text_input: Cell::new(None),
                 is_focusable: focusable,
                 window_level,
@@ -1679,6 +1783,23 @@ impl WindowHandle {
         self.defer(DeferredOp::ShowTitlebar(show_titlebar));
     }
 
+    pub fn set_fullscreen(&self, fullscreen: bool) {
+        if fullscreen {
+            self.defer(DeferredOp::SetWindowState(window::WindowState::Fullscreen));
+        } else {
+            let previously_maximized: bool = self
+                .state
+                .upgrade()
+                .map_or(false, |w| w.saved_plat.get().map_or(false, |p| p.maximized));
+
+            if previously_maximized {
+                self.defer(DeferredOp::SetWindowState(window::WindowState::Maximized));
+            } else {
+                self.defer(DeferredOp::SetWindowState(window::WindowState::Restored));
+            }
+        }
+    }
+
     pub fn set_position(&self, position: Point) {
         self.defer(DeferredOp::SetWindowState(window::WindowState::Restored));
         if let Some(w) = self.state.upgrade() {
@@ -1803,7 +1924,9 @@ impl WindowHandle {
                         Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
                     );
                 }
-                if (style & WS_MAXIMIZE) != 0 {
+                if (style & !WS_CAPTION) != 0 {
+                    window::WindowState::Fullscreen
+                } else if (style & WS_MAXIMIZE) != 0 {
                     window::WindowState::Maximized
                 } else if (style & WS_MINIMIZE) != 0 {
                     window::WindowState::Minimized

--- a/src/backend/x11/application.rs
+++ b/src/backend/x11/application.rs
@@ -107,6 +107,8 @@ x11rb::atom_manager! {
         _NET_WM_WINDOW_TYPE_DROPDOWN_MENU,
         _NET_WM_WINDOW_TYPE_TOOLTIP,
         _NET_WM_WINDOW_TYPE_DIALOG,
+        _NET_WM_STATE,
+        _NET_WM_STATE_FULLSCREEN,
         CLIPBOARD,
         PRIMARY,
         TARGETS,

--- a/src/window.rs
+++ b/src/window.rs
@@ -168,6 +168,7 @@ pub enum WindowState {
     Maximized,
     Minimized,
     Restored,
+    Fullscreen,
 }
 
 /// A handle to a platform window object.
@@ -306,6 +307,11 @@ impl WindowHandle {
     /// Set the title for this menu.
     pub fn set_title(&self, title: &str) {
         self.0.set_title(title)
+    }
+
+    /// Sets / restores borderless fullscreen for the window on the current monitor.
+    pub fn set_fullscreen(&self, fullscreen: bool) {
+        self.0.set_fullscreen(fullscreen)
     }
 
     /// Set the top-level menu for this window.


### PR DESCRIPTION
This adds limited support for a borderless-window `fullscreen' mode on the current monitor.

Task & note list:
- [x] Windows implementation: manual state caching, derived from Chrome's approach.
- [ ] MacOS implementation: TBD
- [x] Linux - x11 implementation: relies on the window manager to cache state, works great under kwin but is untested elsewhere. WindowState getter and setter methods should probably be implemented before this is merged.
- [ ] Linux - GTK implementation: backend is currently broken. Is this a blocker?
- [ ] Linux - Wayland implementation: backend is currently broken.
- [ ] Web implementation: not sure if this is currently possible.
- [ ] Add builder support: not necessarily a good idea as fullscreen requests may fail, but should be here for consistency.
- [ ] Clean up example: derived from shello.rs, it's still longer than necessary.