### PR TITLE
Update AccessKit to 0.11 from 0.9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,8 @@
 
 - Add wgpu triangle example ([#53] by [@lord])
 - Add thread-safe app handle ([#90] by [@clavin])
+- Updated AccessKit to 0.11 ([#108] by [@waywardmonkeys])
+
+[@waywardmonkeys]: https://github.com/waywardmonkeys
+
+[#108]: https://github.com/linebender/glazier/pull/108

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,13 +71,13 @@ memchr = "2.5"
 # Optional dependencies
 image = { version = "0.24.4", optional = true, default_features = false }
 raw-window-handle = { version = "0.5.0", default_features = false }
-accesskit = { version = "0.9.0", optional = true }
+accesskit = { version = "0.11.0", optional = true }
 once_cell = { version = "1", optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
 scopeguard = "1.1.0"
 wio = "0.2.2"
-accesskit_windows = { version = "0.12.0", optional = true }
+accesskit_windows = { version = "0.14.0", optional = true }
 once_cell = "1"
 
 [target.'cfg(target_os="windows")'.dependencies.winapi]
@@ -113,7 +113,7 @@ objc = "0.2.7"
 core-graphics = "0.22.0"
 foreign-types = "0.3.2"
 bitflags = "1.2.1"
-accesskit_macos = { version = "0.5.0", optional = true }
+accesskit_macos = { version = "0.7.0", optional = true }
 
 [target.'cfg(any(target_os = "freebsd", target_os="linux", target_os="openbsd"))'.dependencies]
 ashpd = { version = "0.3.2", optional = true }


### PR DESCRIPTION
This paves the way for updating it within Xilem as well (once that also updates to a current Glazier).