### PR TITLE
Export `MouseInfo`, `PenInfo`, `TouchInfo` structs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - Add wgpu triangle example ([#53] by [@lord])
 - Add thread-safe app handle ([#90] by [@clavin])
 - Updated AccessKit to 0.11 ([#108] by [@waywardmonkeys])
+- Export `MouseInfo`, `PenInfo`, `TouchInfo` for `PointerType` values ([#110] by [@waywardmonkeys])
 
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 
 [#108]: https://github.com/linebender/glazier/pull/108
+[#110]: https://github.com/linebender/glazier/pull/108

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,8 @@ pub use keyboard::{Code, IntoKey, KbKey, KeyEvent, KeyState, Location, Modifiers
 pub use menu::Menu;
 pub use mouse::{Cursor, CursorDesc, MouseButton, MouseButtons, MouseEvent};
 pub use pointer::{
-    PenInclination, PointerButton, PointerButtons, PointerEvent, PointerId, PointerType,
+    MouseInfo, PenInclination, PenInfo, PointerButton, PointerButtons, PointerEvent, PointerId,
+    PointerType, TouchInfo,
 };
 pub use region::Region;
 pub use scale::{Scalable, Scale, ScaledArea};

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -153,6 +153,12 @@ pub struct PenInfo {
 
 impl PenInfo {}
 
+/// Various properties of a touch event.
+///
+/// These follow the web [PointerEvents] specification fairly closely, so see those
+/// documents for more context and nice pictures.
+///
+/// [PointerEvents]: (https://www.w3.org/TR/pointerevents3)
 #[derive(Debug, Clone, PartialEq)]
 pub struct TouchInfo {
     pub contact_geometry: Size,
@@ -160,6 +166,7 @@ pub struct TouchInfo {
     // TODO: Phase?
 }
 
+/// Various properties of a mouse event.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MouseInfo {
     pub wheel_delta: Vec2,


### PR DESCRIPTION
These are used in the `pub` enum `PointerType`, so they were implicitly `pub`, but not included in the generated docs.