### PR TITLE
Fix unused mut warning.

### DIFF
--- a/src/backend/windows/window.rs
+++ b/src/backend/windows/window.rs
@@ -790,7 +790,7 @@ impl WndProc for MyWndProc {
                             // When maximized, windows still adds offsets for the frame
                             // so we counteract them here.
                             let s: *mut NCCALCSIZE_PARAMS = lparam as *mut NCCALCSIZE_PARAMS;
-                            if let Some(mut s) = s.as_mut() {
+                            if let Some(s) = s.as_mut() {
                                 let border = self.get_system_metric(SM_CXPADDEDBORDER);
                                 let frame = self.get_system_metric(SM_CYSIZEFRAME);
                                 s.rgrc[0].top += border + frame;


### PR DESCRIPTION
Interestingly, this happens with 1.71 and nightly. It does not happen with 1.70 or earlier.

Compilation confirmed to work with 1.65 (MSRV for Kurbo).