### PR TITLE
Doc tweaks and improvements.

### DIFF
--- a/src/backend/mac/keyboard.rs
+++ b/src/backend/mac/keyboard.rs
@@ -36,13 +36,13 @@ pub(crate) struct KeyboardState {
     last_mods: NSEventModifierFlags,
 }
 
-/// Convert a macOS platform key code (keyCode field of NSEvent).
+/// Convert a macOS platform key code (`keyCode` field of `NSEvent`).
 ///
 /// The primary source for this mapping is:
 /// <https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code/code_values>
 ///
-/// It should also match up with CODE_MAP_MAC bindings in
-/// NativeKeyToDOMCodeName.h.
+/// It should also match up with `CODE_MAP_MAC` bindings in
+/// `NativeKeyToDOMCodeName.h`.
 fn key_code_to_code(key_code: u16) -> Code {
     match key_code {
         0x00 => Code::KeyA,
@@ -174,13 +174,13 @@ fn key_code_to_code(key_code: u16) -> Code {
 
 /// Convert code to key.
 ///
-/// On macOS, for non-printable keys, the keyCode we get from the event serves is
+/// On macOS, for non-printable keys, the `keyCode` we get from the event serves is
 /// really more of a key than a physical scan code.
 ///
-/// When this function returns None, the code can be considered printable.
+/// When this function returns `None`, the code can be considered printable.
 ///
-/// The logic for this function is derived from KEY_MAP_COCOA bindings in
-/// NativeKeyToDOMKeyName.h.
+/// The logic for this function is derived from `KEY_MAP_COCOA` bindings in
+/// `NativeKeyToDOMKeyName.h`.
 fn code_to_key(code: Code) -> Option<KbKey> {
     Some(match code {
         Code::Escape => KbKey::Escape,

--- a/src/backend/mac/util.rs
+++ b/src/backend/mac/util.rs
@@ -32,7 +32,7 @@ pub(crate) fn assert_main_thread() {
     }
 }
 
-/// Create a new NSString from a &str.
+/// Create a new `NSString` from a `&str`.
 pub(crate) fn make_nsstring(s: &str) -> id {
     unsafe { NSString::alloc(nil).init_str(s).autorelease() }
 }

--- a/src/backend/mac/window.rs
+++ b/src/backend/mac/window.rs
@@ -101,7 +101,7 @@ mod levels {
 
 #[derive(Clone)]
 pub(crate) struct WindowHandle {
-    /// This is an NSView, as our concept of "window" is more the top-level container holding
+    /// This is an `NSView`, as our concept of "window" is more the top-level container holding
     /// a view. Also, this is better for hosted applications such as VST.
     nsview: WeakPtr,
     idle_queue: Weak<Mutex<Vec<IdleKind>>>,
@@ -175,7 +175,7 @@ enum IdleKind {
     DeferredOp(DeferredOp),
 }
 
-/// This is the state associated with our custom NSView.
+/// This is the state associated with our custom `NSView`.
 struct ViewState {
     nsview: WeakPtr,
     handler: Box<dyn WinHandler>,
@@ -315,7 +315,7 @@ impl WindowBuilder {
             view.initWithFrame_(frame);
 
             // The rect of the tracking area doesn't matter, because
-            // we use the InVisibleRect option where the OS syncs the size automatically.
+            // we use the `InVisibleRect` option where the OS syncs the size automatically.
             let rect = NSRect::new(NSPoint::new(0., 0.), NSSize::new(0., 0.));
             let opts = NSTrackingAreaOptions::MouseEnteredAndExited
                 | NSTrackingAreaOptions::MouseMoved
@@ -370,7 +370,7 @@ impl WindowBuilder {
     }
 }
 
-// Wrap pointer because lazy_static requires Sync.
+// Wrap pointer because lazy_static requires [`Sync`].
 struct ViewClass(*const Class);
 unsafe impl Sync for ViewClass {}
 unsafe impl Send for ViewClass {}
@@ -1626,7 +1626,7 @@ impl ViewState {
     }
 }
 
-/// Convert an `Instant` into an NSTimeInterval, i.e. a fractional number
+/// Convert an `Instant` into an `NSTimeInterval`, i.e. a fractional number
 /// of seconds from now.
 ///
 /// This may lose some precision for multi-month durations.

--- a/src/backend/windows/window.rs
+++ b/src/backend/windows/window.rs
@@ -100,7 +100,7 @@ pub(crate) struct WindowBuilder {
 /// with different strategies.
 #[allow(dead_code)]
 pub enum PresentStrategy {
-    /// Corresponds to the swap effect DXGI_SWAP_EFFECT_SEQUENTIAL. It
+    /// Corresponds to the swap effect `DXGI_SWAP_EFFECT_SEQUENTIAL`. It
     /// is compatible with GDI (such as menus), but is not the best in
     /// performance.
     ///
@@ -113,13 +113,13 @@ pub enum PresentStrategy {
     #[default]
     Sequential,
 
-    /// Corresponds to the swap effect DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL.
+    /// Corresponds to the swap effect `DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL`.
     /// In testing, it seems to perform well, but isn't compatible with
     /// GDI. Resize can probably be made to work reasonably smoothly with
     /// additional synchronization work, but has some artifacts.
     Flip,
 
-    /// Corresponds to the swap effect DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL
+    /// Corresponds to the swap effect `DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL`
     /// but with a redirection surface for GDI compatibility. Resize is
     /// very laggy and artifacty.
     FlipRedirect,
@@ -134,7 +134,7 @@ pub enum PresentStrategy {
 /// we'd try to call the `WinHandler` again).
 ///
 /// The solution is that for every `WindowHandle` method that *wants* to return control to the
-/// system's event loop, instead of doing that we queue up a deferrred operation and return
+/// system's event loop, instead of doing that we queue up a deferred operation and return
 /// immediately. The deferred operations will run whenever the currently running `WinHandler`
 /// method returns.
 ///
@@ -196,8 +196,8 @@ unsafe impl HasRawDisplayHandle for WindowHandle {
 }
 
 /// A handle that can get used to schedule an idle handler. Note that
-/// this handle is thread safe. If the handle is used after the hwnd
-/// has been destroyed, probably not much will go wrong (the DS_RUN_IDLE
+/// this handle is thread safe. If the handle is used after the `hwnd`
+/// has been destroyed, probably not much will go wrong (the `DS_RUN_IDLE`
 /// message may be sent to a stray window).
 #[derive(Clone)]
 pub struct IdleHandle {

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -22,8 +22,8 @@ pub use crate::backend::clipboard as backend;
 ///
 /// # Working with text
 ///
-/// Copying and pasting text is simple, using [`Clipboard::put_string`] and
-/// [`Clipboard::get_string`]. If this is all you need, you're in luck.
+/// Copying and pasting text is simple, using [`Clipboard::put_string()`] and
+/// [`Clipboard::get_string()`]. If this is all you need, you're in luck.
 ///
 /// # Advanced usage
 ///
@@ -118,13 +118,9 @@ pub use crate::backend::clipboard as backend;
 /// # fn do_something_with_data(_: &str, _: Vec<u8>) {}
 /// ```
 ///
-/// [`Application::clipboard()`]: struct.Application.html#method.clipboard
-/// [`Clipboard::put_string`]: struct.Clipboard.html#method.put_string
-/// [`Clipboard::get_string`]: struct.Clipboard.html#method.get_string
-/// [`FormatId`]: type.FormatId.html
+/// [`Application::clipboard()`]: crate::Application::clipboard
 /// [`Universal Type Identifier`]: https://escapetech.eu/manuals/qdrop/uti.html
 /// [MIME types]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
-/// [`ClipboardFormat`]: struct.ClipboardFormat.html
 #[derive(Debug, Clone)]
 pub struct Clipboard(pub(crate) backend::Clipboard);
 
@@ -153,10 +149,7 @@ impl Clipboard {
     /// Return data in a given format, if available.
     ///
     /// It is recommended that the [`FormatId`] argument be a format returned by
-    /// [`Clipboard::preferred_format`].
-    ///
-    /// [`Clipboard::preferred_format`]: struct.Clipboard.html#method.preferred_format
-    /// [`FormatId`]: type.FormatId.html
+    /// [`Clipboard::preferred_format()`].
     pub fn get_format(&self, format: FormatId) -> Option<Vec<u8>> {
         self.0.get_format(format)
     }

--- a/src/common_util.rs
+++ b/src/common_util.rs
@@ -55,7 +55,7 @@ pub fn strip_access_key(raw_menu_text: &str) -> String {
 #[cfg_attr(feature = "wayland", allow(unused))]
 pub(crate) type IdleCallback = Box<dyn for<'a> FnOnce(&'a mut dyn WinHandler) + Send>;
 
-/// A sharable queue. Similar to a `std::sync::mpsc` channel, this queue is implmented as two types:
+/// A sharable queue. Similar to a `std::sync::mpsc` channel, this queue is implemented as two types:
 /// [`SharedEnqueuer`] and [`SharedDequeuer`].
 ///
 /// # Comparison to `std::sync::mpsc::channel`

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -53,8 +53,6 @@ use crate::{IntoKey, KbKey, KeyEvent, Modifiers};
 /// assert!(hotkey.matches(KeyEvent::for_test(RawMods::None, KbKey::ArrowLeft)));
 /// assert!(!hotkey.matches(KeyEvent::for_test(RawMods::Ctrl, KbKey::ArrowLeft)));
 /// ```
-///
-/// [`SysMods`]: enum.SysMods.html
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HotKey {
     pub(crate) mods: RawMods,
@@ -82,8 +80,6 @@ impl HotKey {
     /// ```
     ///
     /// [`Key`]: keyboard_types::Key
-    /// [`SysMods`]: enum.SysMods.html
-    /// [`RawMods`]: enum.RawMods.html
     pub fn new(mods: impl Into<Option<RawMods>>, key: impl IntoKey) -> Self {
         HotKey {
             mods: mods.into().unwrap_or(RawMods::None),

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -54,7 +54,7 @@ impl Menu {
     /// Add an item to this menu.
     ///
     /// The `id` should uniquely identify this item. If the user selects this
-    /// item, the responsible [`WindowHandler`]'s [`command()`] method will
+    /// item, the responsible [`WinHandler`]'s [`command()`] method will
     /// be called with this `id`. If the `enabled` argument is false, the menu
     /// item will be grayed out; the hotkey will also be disabled.
     /// If the `selected` argument is `true`, the menu will have a checkmark
@@ -62,10 +62,8 @@ impl Menu {
     /// The `key` argument is an optional [`HotKey`] that will be registered
     /// with the system.
     ///
-    ///
-    /// [`WindowHandler`]: trait.WindowHandler.html
-    /// [`command()`]: trait.WindowHandler.html#tymethod.command
-    /// [`HotKey`]: struct.HotKey.html
+    /// [`WinHandler`]: crate::WinHandler
+    /// [`command()`]: crate::WinHandler::command()
     pub fn add_item(
         &mut self,
         id: u32,

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -27,7 +27,7 @@ use crate::Modifiers;
 pub struct MouseEvent {
     /// The location of the mouse in [display points] in relation to the current window.
     ///
-    /// [display points]: struct.Scale.html
+    /// [display points]: crate::Scale
     pub pos: Point,
     /// Mouse buttons being held down during a move or after a click event.
     /// Thus it will contain the `button` that triggered a mouse-down event,
@@ -118,8 +118,6 @@ impl MouseButton {
 }
 
 /// A set of [`MouseButton`]s.
-///
-/// [`MouseButton`]: enum.MouseButton.html
 #[derive(PartialEq, Eq, Clone, Copy, Default)]
 pub struct MouseButtons(pub(crate) u8);
 
@@ -175,40 +173,30 @@ impl MouseButtons {
     }
 
     /// Returns `true` if [`MouseButton::Left`] is in the set.
-    ///
-    /// [`MouseButton::Left`]: enum.MouseButton.html#variant.Left
     #[inline]
     pub fn has_left(self) -> bool {
         self.contains(MouseButton::Left)
     }
 
     /// Returns `true` if [`MouseButton::Right`] is in the set.
-    ///
-    /// [`MouseButton::Right`]: enum.MouseButton.html#variant.Right
     #[inline]
     pub fn has_right(self) -> bool {
         self.contains(MouseButton::Right)
     }
 
     /// Returns `true` if [`MouseButton::Middle`] is in the set.
-    ///
-    /// [`MouseButton::Middle`]: enum.MouseButton.html#variant.Middle
     #[inline]
     pub fn has_middle(self) -> bool {
         self.contains(MouseButton::Middle)
     }
 
     /// Returns `true` if [`MouseButton::X1`] is in the set.
-    ///
-    /// [`MouseButton::X1`]: enum.MouseButton.html#variant.X1
     #[inline]
     pub fn has_x1(self) -> bool {
         self.contains(MouseButton::X1)
     }
 
     /// Returns `true` if [`MouseButton::X2`] is in the set.
-    ///
-    /// [`MouseButton::X2`]: enum.MouseButton.html#variant.X2
     #[inline]
     pub fn has_x2(self) -> bool {
         self.contains(MouseButton::X2)

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -118,7 +118,7 @@ impl PenInclination {
         let deg_to_rad = PI / 180.0;
 
         // Tilts are not capable of representing angles close to the horizon, so avoid numerical
-        // issues by thresholding the altidue away from the horizon.
+        // issues by thresholding the altitude away from the horizon.
         let altitude_angle = self.altitude.to_radians().max(0.5 * deg_to_rad);
 
         let tan_alt = altitude_angle.tan();
@@ -280,8 +280,6 @@ impl PointerButton {
 }
 
 /// A set of [`PointerButton`]s.
-///
-/// [`PointerButton`]: enum.PointerButton.html
 #[derive(PartialEq, Eq, Clone, Copy, Default)]
 pub struct PointerButtons(u8);
 
@@ -348,40 +346,30 @@ impl PointerButtons {
     }
 
     /// Returns `true` if [`PointerButton::Left`] is in the set.
-    ///
-    /// [`PointerButton::Left`]: enum.PointerButton.html#variant.Left
     #[inline]
     pub fn has_left(self) -> bool {
         self.contains(PointerButton::Left)
     }
 
     /// Returns `true` if [`PointerButton::Right`] is in the set.
-    ///
-    /// [`PointerButton::Right`]: enum.PointerButton.html#variant.Right
     #[inline]
     pub fn has_right(self) -> bool {
         self.contains(PointerButton::Right)
     }
 
     /// Returns `true` if [`PointerButton::Middle`] is in the set.
-    ///
-    /// [`PointerButton::Middle`]: enum.PointerButton.html#variant.Middle
     #[inline]
     pub fn has_middle(self) -> bool {
         self.contains(PointerButton::Middle)
     }
 
     /// Returns `true` if [`PointerButton::X1`] is in the set.
-    ///
-    /// [`PointerButton::X1`]: enum.PointerButton.html#variant.X1
     #[inline]
     pub fn has_x1(self) -> bool {
         self.contains(PointerButton::X1)
     }
 
     /// Returns `true` if [`PointerButton::X2`] is in the set.
-    ///
-    /// [`PointerButton::X2`]: enum.PointerButton.html#variant.X2
     #[inline]
     pub fn has_x2(self) -> bool {
         self.contains(PointerButton::X2)

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -66,8 +66,6 @@ pub struct Scale {
 /// will still match up with the platform area pixel boundaries as often as the scale factor allows.
 ///
 /// A copy of `ScaledArea` will be stale as soon as the platform area size changes.
-///
-/// [`Scale`]: struct.Scale.html
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct ScaledArea {
     /// The size of the scaled area in display points.
@@ -78,8 +76,6 @@ pub struct ScaledArea {
 
 /// The `Scalable` trait describes how coordinates should be translated
 /// from display points into pixels and vice versa using a [`Scale`].
-///
-/// [`Scale`]: struct.Scale.html
 pub trait Scalable {
     /// Converts the scalable item from display points into pixels,
     /// using the x axis scale factor for coordinates on the x axis

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -21,7 +21,7 @@ use std::fmt::Display;
 
 /// Monitor struct containing data about a monitor on the system
 ///
-/// Use `Screen::get_monitors()` to return a `Vec<Monitor>` of all the monitors on the system
+/// Use [`Screen::get_monitors()`] to return a `Vec<Monitor>` of all the monitors on the system
 #[derive(Clone, Debug, PartialEq)]
 pub struct Monitor {
     primary: bool,
@@ -82,7 +82,7 @@ pub struct Screen {}
 impl Screen {
     /// Returns a vector of all the [`monitors`] on the system.
     ///
-    /// [`monitors`]: struct.Monitor.html
+    /// [`monitors`]: Monitor
     pub fn get_monitors() -> Vec<Monitor> {
         backend::screen::get_monitors()
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -104,7 +104,7 @@ impl IdleHandle {
         self.0.add_idle_callback(callback)
     }
 
-    /// Request a callback from the runloop. Your `WinHander::idle` method will
+    /// Request a callback from the runloop. Your [`WinHandler::idle`] method will
     /// be called with the `token` that was passed in.
     pub fn schedule_idle(&mut self, token: IdleToken) {
         self.0.add_idle_token(token)
@@ -645,8 +645,8 @@ pub trait WinHandler {
         false
     }
 
-    /// Called when a key is released. This corresponds to the WM_KEYUP message
-    /// on Windows, or keyUp(withEvent:) on macOS.
+    /// Called when a key is released. This corresponds to the `WM_KEYUP` message
+    /// on Windows, or `keyUp(withEvent:)` on macOS.
     #[allow(unused_variables)]
     fn key_up(&mut self, event: KeyEvent) {}
 
@@ -767,8 +767,8 @@ pub trait WinHandler {
     fn request_close(&mut self) {}
 
     /// Called when the window is being destroyed. Note that this happens
-    /// earlier in the sequence than drop (at WM_DESTROY, while the latter is
-    /// WM_NCDESTROY).
+    /// earlier in the sequence than drop (at `WM_DESTROY`, while the latter is
+    /// `WM_NCDESTROY`).
     #[allow(unused_variables)]
     fn destroy(&mut self) {}
 


### PR DESCRIPTION
This fixes some typos and formatting. It also changes to using intra-doc-links rather than links to the rustdoc-generated HTML.