### PR TITLE
Fix building with the accesskit feature on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
 
       - name: cargo build accesskit example
         run: cargo build --features accesskit --example accesskit
-        if: contains(matrix.os, 'macos') || contains(matrix.os, 'windows')
 
   # we test the wayland backend as a separate job
   test-stable-wayland:

--- a/src/backend/linux/window.rs
+++ b/src/backend/linux/window.rs
@@ -677,6 +677,20 @@ impl WindowHandle {
             WindowHandle::None => panic!("Used an uninitialised WindowHandle"),
         }
     }
+
+    #[cfg(feature = "accesskit")]
+    pub fn update_accesskit_if_active(
+        &self,
+        update_factory: impl FnOnce() -> accesskit::TreeUpdate,
+    ) {
+        match self {
+            #[cfg(feature = "x11")]
+            WindowHandle::X11(handle) => handle.update_accesskit_if_active(update_factory),
+            #[cfg(feature = "wayland")]
+            WindowHandle::Wayland(handle) => handle.update_accesskit_if_active(update_factory),
+            WindowHandle::None => panic!("Used an uninitialised WindowHandle"),
+        }
+    }
 }
 
 unsafe impl HasRawWindowHandle for WindowHandle {


### PR DESCRIPTION
Fixes #112 

Unfortunately, I've so far been unable to find documentation of whether accessibility in Accesskit is application or window scoped, so am yet to integrate accesskit_unix. Depending on the results of today's office hours, I may add that integration into this PR - otherwise, it will follow up.