### PR TITLE
impl `fmt::Debug` for `WindowLevel`.

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -15,6 +15,7 @@
 //! Platform independent window types.
 
 use std::any::Any;
+use std::fmt;
 use std::time::Duration;
 
 use crate::application::Application;
@@ -160,6 +161,17 @@ pub enum WindowLevel {
     DropDown(WindowHandle),
     /// A modal dialog
     Modal(WindowHandle),
+}
+
+impl fmt::Debug for WindowLevel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            WindowLevel::AppWindow => write!(f, "AppWindow"),
+            WindowLevel::Tooltip(_) => write!(f, "Tooltip"),
+            WindowLevel::DropDown(_) => write!(f, "DropDown"),
+            WindowLevel::Modal(_) => write!(f, "Modal"),
+        }
+    }
 }
 
 /// Contains the different states a Window can be in.


### PR DESCRIPTION
Fixes #24.