### PR TITLE
Rename `MouseButton`/`PointerButton` variants.

### DIFF
--- a/src/backend/mac/window.rs
+++ b/src/backend/mac/window.rs
@@ -713,9 +713,9 @@ fn mouse_event(
 
 fn get_mouse_button(button: NSInteger) -> Option<MouseButton> {
     match button {
-        0 => Some(MouseButton::Left),
-        1 => Some(MouseButton::Right),
-        2 => Some(MouseButton::Middle),
+        0 => Some(MouseButton::Primary),
+        1 => Some(MouseButton::Secondary),
+        2 => Some(MouseButton::Auxiliary),
         3 => Some(MouseButton::X1),
         4 => Some(MouseButton::X2),
         _ => None,
@@ -725,13 +725,13 @@ fn get_mouse_button(button: NSInteger) -> Option<MouseButton> {
 fn get_mouse_buttons(mask: NSUInteger) -> MouseButtons {
     let mut buttons = MouseButtons::new();
     if mask & 1 != 0 {
-        buttons.insert(MouseButton::Left);
+        buttons.insert(MouseButton::Primary);
     }
     if mask & 1 << 1 != 0 {
-        buttons.insert(MouseButton::Right);
+        buttons.insert(MouseButton::Secondary);
     }
     if mask & 1 << 2 != 0 {
-        buttons.insert(MouseButton::Middle);
+        buttons.insert(MouseButton::Auxiliary);
     }
     if mask & 1 << 3 != 0 {
         buttons.insert(MouseButton::X1);
@@ -773,11 +773,11 @@ fn check_if_layer_delegate_install_needed(view: *mut Object, view_state: &mut Vi
 }
 
 extern "C" fn mouse_down_left(this: &mut Object, _: Sel, nsevent: id) {
-    mouse_down(this, nsevent, MouseButton::Left);
+    mouse_down(this, nsevent, MouseButton::Primary);
 }
 
 extern "C" fn mouse_down_right(this: &mut Object, _: Sel, nsevent: id) {
-    mouse_down(this, nsevent, MouseButton::Right);
+    mouse_down(this, nsevent, MouseButton::Secondary);
 }
 
 extern "C" fn mouse_down_other(this: &mut Object, _: Sel, nsevent: id) {
@@ -793,18 +793,18 @@ fn mouse_down(this: &mut Object, nsevent: id, button: MouseButton) {
         let view_state: *mut c_void = *this.get_ivar("viewState");
         let view_state = &mut *(view_state as *mut ViewState);
         let count = nsevent.clickCount() as u8;
-        let focus = view_state.focus_click && button == MouseButton::Left;
+        let focus = view_state.focus_click && button == MouseButton::Primary;
         let event = mouse_event(nsevent, this as id, count, focus, button, Vec2::ZERO);
         view_state.handler.mouse_down(&event);
     }
 }
 
 extern "C" fn mouse_up_left(this: &mut Object, _: Sel, nsevent: id) {
-    mouse_up(this, nsevent, MouseButton::Left);
+    mouse_up(this, nsevent, MouseButton::Primary);
 }
 
 extern "C" fn mouse_up_right(this: &mut Object, _: Sel, nsevent: id) {
-    mouse_up(this, nsevent, MouseButton::Right);
+    mouse_up(this, nsevent, MouseButton::Secondary);
 }
 
 extern "C" fn mouse_up_other(this: &mut Object, _: Sel, nsevent: id) {
@@ -819,7 +819,7 @@ fn mouse_up(this: &mut Object, nsevent: id, button: MouseButton) {
     unsafe {
         let view_state: *mut c_void = *this.get_ivar("viewState");
         let view_state = &mut *(view_state as *mut ViewState);
-        let focus = if view_state.focus_click && button == MouseButton::Left {
+        let focus = if view_state.focus_click && button == MouseButton::Primary {
             view_state.focus_click = false;
             true
         } else {

--- a/src/backend/web/window.rs
+++ b/src/backend/web/window.rs
@@ -767,9 +767,9 @@ impl IdleHandle {
 
 fn mouse_button(button: i16) -> Option<MouseButton> {
     match button {
-        0 => Some(MouseButton::Left),
-        1 => Some(MouseButton::Middle),
-        2 => Some(MouseButton::Right),
+        0 => Some(MouseButton::Primary),
+        1 => Some(MouseButton::Auxiliary),
+        2 => Some(MouseButton::Secondary),
         3 => Some(MouseButton::X1),
         4 => Some(MouseButton::X2),
         _ => None,
@@ -779,13 +779,13 @@ fn mouse_button(button: i16) -> Option<MouseButton> {
 fn mouse_buttons(mask: u16) -> MouseButtons {
     let mut buttons = MouseButtons::new();
     if mask & 1 != 0 {
-        buttons.insert(MouseButton::Left);
+        buttons.insert(MouseButton::Primary);
     }
     if mask & 1 << 1 != 0 {
-        buttons.insert(MouseButton::Right);
+        buttons.insert(MouseButton::Secondary);
     }
     if mask & 1 << 2 != 0 {
-        buttons.insert(MouseButton::Middle);
+        buttons.insert(MouseButton::Auxiliary);
     }
     if mask & 1 << 3 != 0 {
         buttons.insert(MouseButton::X1);

--- a/src/backend/windows/window.rs
+++ b/src/backend/windows/window.rs
@@ -321,13 +321,13 @@ pub(crate) const DS_REQUEST_DESTROY: UINT = WM_USER + 1;
 fn get_buttons(wparam: WPARAM) -> MouseButtons {
     let mut buttons = MouseButtons::new();
     if wparam & MK_LBUTTON != 0 {
-        buttons.insert(MouseButton::Left);
+        buttons.insert(MouseButton::Primary);
     }
     if wparam & MK_RBUTTON != 0 {
-        buttons.insert(MouseButton::Right);
+        buttons.insert(MouseButton::Secondary);
     }
     if wparam & MK_MBUTTON != 0 {
-        buttons.insert(MouseButton::Middle);
+        buttons.insert(MouseButton::Auxiliary);
     }
     if wparam & MK_XBUTTON1 != 0 {
         buttons.insert(MouseButton::X1);
@@ -1041,9 +1041,13 @@ impl WndProc for MyWndProc {
             | WM_RBUTTONDOWN | WM_RBUTTONUP | WM_MBUTTONDBLCLK | WM_MBUTTONDOWN | WM_MBUTTONUP
             | WM_XBUTTONDBLCLK | WM_XBUTTONDOWN | WM_XBUTTONUP => {
                 if let Some(button) = match msg {
-                    WM_LBUTTONDBLCLK | WM_LBUTTONDOWN | WM_LBUTTONUP => Some(MouseButton::Left),
-                    WM_RBUTTONDBLCLK | WM_RBUTTONDOWN | WM_RBUTTONUP => Some(MouseButton::Right),
-                    WM_MBUTTONDBLCLK | WM_MBUTTONDOWN | WM_MBUTTONUP => Some(MouseButton::Middle),
+                    WM_LBUTTONDBLCLK | WM_LBUTTONDOWN | WM_LBUTTONUP => Some(MouseButton::Primary),
+                    WM_RBUTTONDBLCLK | WM_RBUTTONDOWN | WM_RBUTTONUP => {
+                        Some(MouseButton::Secondary)
+                    }
+                    WM_MBUTTONDBLCLK | WM_MBUTTONDOWN | WM_MBUTTONUP => {
+                        Some(MouseButton::Auxiliary)
+                    }
                     WM_XBUTTONDBLCLK | WM_XBUTTONDOWN | WM_XBUTTONUP => {
                         match HIWORD(wparam as u32) {
                             XBUTTON1 => Some(MouseButton::X1),

--- a/src/backend/x11/window.rs
+++ b/src/backend/x11/window.rs
@@ -841,7 +841,7 @@ impl Window {
             pressure: 0.0,
         });
         let button = if is_primary {
-            PointerButton::Left
+            PointerButton::Primary
         } else {
             PointerButton::None
         };
@@ -1077,9 +1077,9 @@ impl Window {
 fn pointer_button(button: u32) -> PointerButton {
     match button {
         0 => PointerButton::None,
-        1 => PointerButton::Left,
-        2 => PointerButton::Middle,
-        3 => PointerButton::Right,
+        1 => PointerButton::Primary,
+        2 => PointerButton::Auxiliary,
+        3 => PointerButton::Secondary,
         // buttons 4 through 7 are for scrolling.
         4..=7 => PointerButton::None,
         8 => PointerButton::X1,
@@ -1096,9 +1096,9 @@ fn pointer_button(button: u32) -> PointerButton {
 fn pointer_buttons(mods: KeyButMask) -> PointerButtons {
     let mut buttons = PointerButtons::new();
     let button_masks = &[
-        (xproto::ButtonMask::M1, PointerButton::Left),
-        (xproto::ButtonMask::M2, PointerButton::Middle),
-        (xproto::ButtonMask::M3, PointerButton::Right),
+        (xproto::ButtonMask::M1, PointerButton::Primary),
+        (xproto::ButtonMask::M2, PointerButton::Auxiliary),
+        (xproto::ButtonMask::M3, PointerButton::Secondary),
         // TODO: determine the X1/X2 state, using our own caching if necessary.
         // BUTTON_MASK_4/5 do not work: they are for scroll events.
     ];

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -39,7 +39,7 @@ pub struct MouseEvent {
     /// be `0` for a mouse-up and mouse-move events.
     pub count: u8,
     /// Focus is `true` on macOS when the mouse-down event (or its companion mouse-up event)
-    /// with `MouseButton::Left` was the event that caused the window to gain focus.
+    /// with `MouseButton::Primary` was the event that caused the window to gain focus.
     pub focus: bool,
     /// The button that was pressed down in the case of mouse-down,
     /// or the button that was released in the case of mouse-up.
@@ -63,12 +63,12 @@ pub enum MouseButton {
     /// No mouse button.
     // MUST BE FIRST (== 0)
     None,
-    /// Left mouse button.
-    Left,
-    /// Right mouse button.
-    Right,
-    /// Middle mouse button.
-    Middle,
+    /// Primary mouse button, commonly the left mouse button.
+    Primary,
+    /// Secondary mouse button, commonly the right mouse button.
+    Secondary,
+    /// Auxiliary mouse button, commonly the middle mouse button.
+    Auxiliary,
     /// First X button.
     X1,
     /// Second X button.
@@ -76,22 +76,22 @@ pub enum MouseButton {
 }
 
 impl MouseButton {
-    /// Returns `true` if this is [`MouseButton::Left`].
+    /// Returns `true` if this is [`MouseButton::Primary`].
     #[inline]
-    pub fn is_left(self) -> bool {
-        self == MouseButton::Left
+    pub fn is_primary(self) -> bool {
+        self == MouseButton::Primary
     }
 
-    /// Returns `true` if this is [`MouseButton::Right`].
+    /// Returns `true` if this is [`MouseButton::Secondary`].
     #[inline]
-    pub fn is_right(self) -> bool {
-        self == MouseButton::Right
+    pub fn is_secondary(self) -> bool {
+        self == MouseButton::Secondary
     }
 
-    /// Returns `true` if this is [`MouseButton::Middle`].
+    /// Returns `true` if this is [`MouseButton::Auxiliary`].
     #[inline]
-    pub fn is_middle(self) -> bool {
-        self == MouseButton::Middle
+    pub fn is_auxiliary(self) -> bool {
+        self == MouseButton::Auxiliary
     }
 
     /// Returns `true` if this is [`MouseButton::X1`].
@@ -162,22 +162,22 @@ impl MouseButtons {
         self.0 & buttons.0 == buttons.0
     }
 
-    /// Returns `true` if [`MouseButton::Left`] is in the set.
+    /// Returns `true` if [`MouseButton::Primary`] is in the set.
     #[inline]
-    pub fn has_left(self) -> bool {
-        self.contains(MouseButton::Left)
+    pub fn has_primary(self) -> bool {
+        self.contains(MouseButton::Primary)
     }
 
-    /// Returns `true` if [`MouseButton::Right`] is in the set.
+    /// Returns `true` if [`MouseButton::Secondary`] is in the set.
     #[inline]
-    pub fn has_right(self) -> bool {
-        self.contains(MouseButton::Right)
+    pub fn has_secondary(self) -> bool {
+        self.contains(MouseButton::Secondary)
     }
 
-    /// Returns `true` if [`MouseButton::Middle`] is in the set.
+    /// Returns `true` if [`MouseButton::Auxiliary`] is in the set.
     #[inline]
-    pub fn has_middle(self) -> bool {
-        self.contains(MouseButton::Middle)
+    pub fn has_auxiliary(self) -> bool {
+        self.contains(MouseButton::Auxiliary)
     }
 
     /// Returns `true` if [`MouseButton::X1`] is in the set.

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -212,12 +212,12 @@ pub enum PointerButton {
     /// No mouse button.
     // MUST BE FIRST (== 0)
     None,
-    /// Left mouse button, Left Mouse, Touch Contact, Pen contact.
-    Left,
-    /// Right mouse button, Right Mouse, Pen barrel button.
-    Right,
-    /// Middle mouse button.
-    Middle,
+    /// Primary button, commonly the left mouse button, touch contact, pen contact.
+    Primary,
+    /// Secondary button, commonly the right mouse button, pen barrel button.
+    Secondary,
+    /// Auxiliary button, commonly the middle mouse button.
+    Auxiliary,
     /// X1 (back) Mouse.
     X1,
     /// X2 (forward) Mouse.
@@ -228,9 +228,9 @@ impl From<crate::MouseButton> for PointerButton {
     fn from(m: crate::MouseButton) -> Self {
         match m {
             crate::MouseButton::None => PointerButton::None,
-            crate::MouseButton::Left => PointerButton::Left,
-            crate::MouseButton::Right => PointerButton::Right,
-            crate::MouseButton::Middle => PointerButton::Middle,
+            crate::MouseButton::Primary => PointerButton::Primary,
+            crate::MouseButton::Secondary => PointerButton::Secondary,
+            crate::MouseButton::Auxiliary => PointerButton::Auxiliary,
             crate::MouseButton::X1 => PointerButton::X1,
             crate::MouseButton::X2 => PointerButton::X2,
         }
@@ -238,22 +238,22 @@ impl From<crate::MouseButton> for PointerButton {
 }
 
 impl PointerButton {
-    /// Returns `true` if this is [`PointerButton::Left`].
+    /// Returns `true` if this is [`PointerButton::Primary`].
     #[inline]
-    pub fn is_left(self) -> bool {
-        self == PointerButton::Left
+    pub fn is_primary(self) -> bool {
+        self == PointerButton::Primary
     }
 
-    /// Returns `true` if this is [`PointerButton::Right`].
+    /// Returns `true` if this is [`PointerButton::Secondary`].
     #[inline]
-    pub fn is_right(self) -> bool {
-        self == PointerButton::Right
+    pub fn is_secondary(self) -> bool {
+        self == PointerButton::Secondary
     }
 
-    /// Returns `true` if this is [`PointerButton::Middle`].
+    /// Returns `true` if this is [`PointerButton::Auxiliary`].
     #[inline]
-    pub fn is_middle(self) -> bool {
-        self == PointerButton::Middle
+    pub fn is_auxiliary(self) -> bool {
+        self == PointerButton::Auxiliary
     }
 
     /// Returns `true` if this is [`PointerButton::X1`].
@@ -276,9 +276,9 @@ pub struct PointerButtons(u8);
 fn button_bit(button: PointerButton) -> u8 {
     match button {
         PointerButton::None => 0,
-        PointerButton::Left => 0b1,
-        PointerButton::Right => 0b10,
-        PointerButton::Middle => 0b100,
+        PointerButton::Primary => 0b1,
+        PointerButton::Secondary => 0b10,
+        PointerButton::Auxiliary => 0b100,
         PointerButton::X1 => 0b1000,
         PointerButton::X2 => 0b10000,
     }
@@ -335,22 +335,22 @@ impl PointerButtons {
         self.0 & buttons.0 == buttons.0
     }
 
-    /// Returns `true` if [`PointerButton::Left`] is in the set.
+    /// Returns `true` if [`PointerButton::Primary`] is in the set.
     #[inline]
-    pub fn has_left(self) -> bool {
-        self.contains(PointerButton::Left)
+    pub fn has_primary(self) -> bool {
+        self.contains(PointerButton::Primary)
     }
 
-    /// Returns `true` if [`PointerButton::Right`] is in the set.
+    /// Returns `true` if [`PointerButton::Secondary`] is in the set.
     #[inline]
-    pub fn has_right(self) -> bool {
-        self.contains(PointerButton::Right)
+    pub fn has_secondary(self) -> bool {
+        self.contains(PointerButton::Secondary)
     }
 
-    /// Returns `true` if [`PointerButton::Middle`] is in the set.
+    /// Returns `true` if [`PointerButton::Auxiliary`] is in the set.
     #[inline]
-    pub fn has_middle(self) -> bool {
-        self.contains(PointerButton::Middle)
+    pub fn has_auxiliary(self) -> bool {
+        self.contains(PointerButton::Auxiliary)
     }
 
     /// Returns `true` if [`PointerButton::X1`] is in the set.
@@ -421,7 +421,7 @@ pub struct PointerEvent {
     pub button: PointerButton,
 
     /// Focus is `true` on macOS when the mouse-down event (or its companion mouse-up event)
-    /// with `MouseButton::Left` was the event that caused the window to gain focus.
+    /// with `MouseButton::Primary` was the event that caused the window to gain focus.
     pub focus: bool,
 
     // TODO: Should this be here, or only in mouse/pen events?


### PR DESCRIPTION
As described in issue #88, the web specifications that we are tracking refer to the mouse buttons as primary/secondary/auxillary rather than left/right/middle.

Fixes #88.