### PR TITLE
Pass `PointerEvent`/`MouseEvent` by value, not ref.

### DIFF
--- a/examples/pen.rs
+++ b/examples/pen.rs
@@ -158,11 +158,11 @@ impl WinHandler for WindowState {
         println!("keyup: {event:?}");
     }
 
-    fn wheel(&mut self, event: &PointerEvent) {
+    fn wheel(&mut self, event: PointerEvent) {
         println!("wheel {event:?}");
     }
 
-    fn pointer_move(&mut self, event: &PointerEvent) {
+    fn pointer_move(&mut self, event: PointerEvent) {
         self.handle.set_cursor(&Cursor::Arrow);
         match &event.pointer_type {
             PointerType::Pen(info) => {
@@ -183,7 +183,7 @@ impl WinHandler for WindowState {
         }
     }
 
-    fn pointer_down(&mut self, event: &PointerEvent) {
+    fn pointer_down(&mut self, event: PointerEvent) {
         if let PointerType::Touch(_) = &event.pointer_type {
             let color = if event.is_primary {
                 Color::RED
@@ -198,7 +198,7 @@ impl WinHandler for WindowState {
         }
     }
 
-    fn pointer_up(&mut self, event: &PointerEvent) {
+    fn pointer_up(&mut self, event: PointerEvent) {
         if let PointerType::Touch(_) = &event.pointer_type {
             self.touch_state.points.remove(&event.pointer_id);
         }

--- a/examples/shello.rs
+++ b/examples/shello.rs
@@ -139,20 +139,20 @@ impl WinHandler for WindowState {
         println!("keyup: {event:?}");
     }
 
-    fn wheel(&mut self, event: &PointerEvent) {
+    fn wheel(&mut self, event: PointerEvent) {
         println!("wheel {event:?}");
     }
 
-    fn pointer_move(&mut self, _event: &PointerEvent) {
+    fn pointer_move(&mut self, _event: PointerEvent) {
         self.handle.set_cursor(&Cursor::Arrow);
         //println!("pointer_move {event:?}");
     }
 
-    fn pointer_down(&mut self, event: &PointerEvent) {
+    fn pointer_down(&mut self, event: PointerEvent) {
         println!("pointer_down {event:?}");
     }
 
-    fn pointer_up(&mut self, event: &PointerEvent) {
+    fn pointer_up(&mut self, event: PointerEvent) {
         println!("pointer_up {event:?}");
     }
 

--- a/src/backend/mac/window.rs
+++ b/src/backend/mac/window.rs
@@ -797,7 +797,7 @@ fn mouse_down(this: &mut Object, nsevent: id, button: PointerButton) {
         let count = nsevent.clickCount() as u8;
         let focus = view_state.focus_click && button == PointerButton::Primary;
         let event = mouse_pointer_event(nsevent, this as id, count, focus, button, Vec2::ZERO);
-        view_state.handler.pointer_down(&event);
+        view_state.handler.pointer_down(event);
     }
 }
 
@@ -828,13 +828,14 @@ fn mouse_up(this: &mut Object, nsevent: id, button: PointerButton) {
             false
         };
         let event = mouse_pointer_event(nsevent, this as id, 0, focus, button, Vec2::ZERO);
-        view_state.handler.pointer_up(&event);
+        let buttons = event.buttons; // Copy for check after event is consumed.
+        view_state.handler.pointer_up(event);
         // If we have already received a mouseExited event then that means
         // we're still receiving mouse events because some buttons are being held down.
         // When the last held button is released and we haven't received a mouseEntered event,
         // then we will no longer receive mouse events until the next mouseEntered event
         // and need to inform the handler of the mouse leaving.
-        if view_state.mouse_left && event.buttons.is_empty() {
+        if view_state.mouse_left && buttons.is_empty() {
             view_state.handler.pointer_leave();
         }
     }
@@ -852,7 +853,7 @@ extern "C" fn mouse_move(this: &mut Object, _: Sel, nsevent: id) {
             PointerButton::None,
             Vec2::ZERO,
         );
-        view_state.handler.pointer_move(&event);
+        view_state.handler.pointer_move(event);
     }
 }
 
@@ -862,7 +863,7 @@ extern "C" fn mouse_enter(this: &mut Object, _sel: Sel, nsevent: id) {
         let view_state = &mut *(view_state as *mut ViewState);
         view_state.mouse_left = false;
         let event = mouse_pointer_event(nsevent, this, 0, false, PointerButton::None, Vec2::ZERO);
-        view_state.handler.pointer_move(&event);
+        view_state.handler.pointer_move(event);
     }
 }
 
@@ -897,7 +898,7 @@ extern "C" fn scroll_wheel(this: &mut Object, _: Sel, nsevent: id) {
             PointerButton::None,
             Vec2::new(dx, dy),
         );
-        view_state.handler.wheel(&event);
+        view_state.handler.wheel(event);
     }
 }
 

--- a/src/backend/web/window.rs
+++ b/src/backend/web/window.rs
@@ -215,7 +215,7 @@ fn setup_mouse_down_callback(ws: &Rc<WindowState>) {
                 focus: false,
                 count,
             };
-            state.handler.borrow_mut().pointer_down(&event);
+            state.handler.borrow_mut().pointer_down(event);
         }
     });
 }
@@ -237,7 +237,7 @@ fn setup_mouse_up_callback(ws: &Rc<WindowState>) {
                 focus: false,
                 count: 0,
             };
-            state.handler.borrow_mut().pointer_up(&event);
+            state.handler.borrow_mut().pointer_up(event);
         }
     });
 }
@@ -258,7 +258,7 @@ fn setup_mouse_move_callback(ws: &Rc<WindowState>) {
             focus: false,
             count: 0,
         };
-        state.handler.borrow_mut().pointer_move(&event);
+        state.handler.borrow_mut().pointer_move(event);
     });
 }
 
@@ -295,7 +295,7 @@ fn setup_scroll_callback(ws: &Rc<WindowState>) {
             focus: false,
             count: 0,
         };
-        state.handler.borrow_mut().wheel(&event);
+        state.handler.borrow_mut().wheel(event);
     });
 }
 

--- a/src/backend/windows/window.rs
+++ b/src/backend/windows/window.rs
@@ -976,7 +976,7 @@ impl WndProc for MyWndProc {
                         focus: false,
                         count: 0,
                     };
-                    s.handler.wheel(&event);
+                    s.handler.wheel(event);
                     true
                 });
                 if handled == Some(false) {
@@ -1026,7 +1026,7 @@ impl WndProc for MyWndProc {
                         focus: false,
                         count: 0,
                     };
-                    s.handler.pointer_move(&event);
+                    s.handler.pointer_move(event);
                 });
                 Some(0)
             }
@@ -1115,9 +1115,9 @@ impl WndProc for MyWndProc {
                         };
                         if count > 0 {
                             s.enter_pointer_capture(hwnd, button);
-                            s.handler.pointer_down(&event);
+                            s.handler.pointer_down(event);
                         } else {
-                            s.handler.pointer_up(&event);
+                            s.handler.pointer_up(event);
                             if s.exit_pointer_capture(button) {
                                 self.handle.borrow().defer(DeferredOp::ReleaseMouseCapture);
                             }

--- a/src/backend/x11/window.rs
+++ b/src/backend/x11/window.rs
@@ -925,7 +925,7 @@ impl Window {
         pointer_ev.buttons = pointer_ev.buttons.with(pointer_ev.button);
         // TODO: detect the count
         pointer_ev.count = 1;
-        self.with_handler(|h| h.pointer_down(&pointer_ev));
+        self.with_handler(|h| h.pointer_down(pointer_ev));
         Ok(())
     }
 
@@ -934,27 +934,27 @@ impl Window {
         // The xcb state includes the newly released button, but druid
         // doesn't want it.
         pointer_ev.buttons = pointer_ev.buttons.without(pointer_ev.button);
-        self.with_handler(|h| h.pointer_up(&pointer_ev));
+        self.with_handler(|h| h.pointer_up(pointer_ev));
         Ok(())
     }
 
     pub fn handle_touch_begin(&self, ev: &xinput::TouchBeginEvent) -> Result<(), Error> {
         let mut pointer_ev = self.pointer_touch_event(ev);
         pointer_ev.buttons = pointer_ev.buttons.with(pointer_ev.button);
-        self.with_handler(|h| h.pointer_down(&pointer_ev));
+        self.with_handler(|h| h.pointer_down(pointer_ev));
         Ok(())
     }
 
     pub fn handle_touch_update(&self, ev: &xinput::TouchBeginEvent) -> Result<(), Error> {
         let pointer_ev = self.pointer_touch_event(ev);
-        self.with_handler(|h| h.pointer_move(&pointer_ev));
+        self.with_handler(|h| h.pointer_move(pointer_ev));
         Ok(())
     }
 
     pub fn handle_touch_end(&self, ev: &xinput::TouchBeginEvent) -> Result<(), Error> {
         let mut pointer_ev = self.pointer_touch_event(ev);
         pointer_ev.buttons = pointer_ev.buttons.without(pointer_ev.button);
-        self.with_handler(|h| h.pointer_move(&pointer_ev));
+        self.with_handler(|h| h.pointer_move(pointer_ev));
         Ok(())
     }
 
@@ -977,14 +977,14 @@ impl Window {
         });
         pointer_ev.button = PointerButton::None;
 
-        self.with_handler(|h| h.wheel(&pointer_ev));
+        self.with_handler(|h| h.wheel(pointer_ev));
         Ok(())
     }
 
     pub fn handle_motion_notify(&self, ev: &xinput::ButtonPressEvent) -> Result<(), Error> {
         let mut pointer_ev = self.pointer_event(ev);
         pointer_ev.button = PointerButton::None;
-        self.with_handler(|h| h.pointer_move(&pointer_ev));
+        self.with_handler(|h| h.pointer_move(pointer_ev));
         Ok(())
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -705,23 +705,23 @@ pub trait WinHandler {
     ///
     /// [WheelEvent]: https://w3c.github.io/uievents/#event-type-wheel
     #[allow(unused_variables)]
-    fn wheel(&mut self, event: &PointerEvent) {}
+    fn wheel(&mut self, event: PointerEvent) {}
 
     /// Called when a pointer moves.
     #[allow(unused_variables)]
-    fn pointer_move(&mut self, event: &PointerEvent) {}
+    fn pointer_move(&mut self, event: PointerEvent) {}
 
     /// Called when a pointer goes "down."
     ///
     /// This includes things like mouse button presses, and styli coming in contact with screens.
     #[allow(unused_variables)]
-    fn pointer_down(&mut self, event: &PointerEvent) {}
+    fn pointer_down(&mut self, event: PointerEvent) {}
 
     /// Called when a pointer goes "up."
     ///
     /// This includes things like mouse button releases, and styli lifting from screens.
     #[allow(unused_variables)]
-    fn pointer_up(&mut self, event: &PointerEvent) {}
+    fn pointer_up(&mut self, event: PointerEvent) {}
 
     /// Called when a pointer has left the application window.
     fn pointer_leave(&mut self) {}


### PR DESCRIPTION
This makes it match `KeyboardEvent`.