### PR TITLE
Stop wrapping keyboard_types::Modifiers.

### DIFF
--- a/src/backend/mac/menu.rs
+++ b/src/backend/mac/menu.rs
@@ -22,7 +22,7 @@ use objc::{msg_send, sel, sel_impl};
 use super::util::make_nsstring;
 use crate::common_util::strip_access_key;
 use crate::hotkey::HotKey;
-use crate::keyboard::{KbKey, Modifiers};
+use crate::keyboard::{KbKey, Modifiers, ModifiersExt};
 
 pub struct Menu {
     pub menu: id,

--- a/src/backend/windows/keyboard.rs
+++ b/src/backend/windows/keyboard.rs
@@ -20,7 +20,7 @@ use std::convert::TryInto;
 use std::mem;
 use std::ops::RangeInclusive;
 
-use crate::keyboard::{Code, KbKey, KeyEvent, KeyState, Location, Modifiers};
+use crate::keyboard::{Code, KbKey, KeyEvent, KeyState, Location, Modifiers, ModifiersExt};
 
 use winapi::shared::minwindef::{HKL, INT, LPARAM, UINT, WPARAM};
 use winapi::shared::ntdef::SHORT;

--- a/src/backend/windows/menu.rs
+++ b/src/backend/windows/menu.rs
@@ -25,7 +25,7 @@ use winapi::um::winuser::*;
 
 use super::util::ToWide;
 use crate::hotkey::HotKey;
-use crate::keyboard::{KbKey, Modifiers};
+use crate::keyboard::{KbKey, Modifiers, ModifiersExt};
 
 /// A menu object, which can be either a top-level menubar or a
 /// submenu.

--- a/src/backend/windows/window.rs
+++ b/src/backend/windows/window.rs
@@ -62,7 +62,7 @@ use super::util::{self, ToWide, OPTIONAL_FUNCTIONS};
 use crate::common_util::IdleCallback;
 use crate::dialog::{FileDialogOptions, FileDialogType, FileInfo};
 use crate::error::Error as ShellError;
-use crate::keyboard::{KbKey, KeyState};
+use crate::keyboard::{KbKey, KeyState, ModifiersExt};
 use crate::mouse::{Cursor, CursorDesc};
 use crate::pointer::{
     MouseInfo, PointerButton, PointerButtons, PointerEvent, PointerId, PointerType,

--- a/src/backend/x11/window.rs
+++ b/src/backend/x11/window.rs
@@ -51,7 +51,7 @@ use crate::backend::shared::Timer;
 use crate::common_util::IdleCallback;
 use crate::dialog::FileDialogOptions;
 use crate::error::Error as ShellError;
-use crate::keyboard::{KeyState, Modifiers};
+use crate::keyboard::{KeyState, Modifiers, ModifiersExt};
 use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 use crate::mouse::{Cursor, CursorDesc};
 use crate::region::Region;

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -18,7 +18,7 @@ use std::borrow::Borrow;
 
 use tracing::warn;
 
-use crate::{IntoKey, KbKey, KeyEvent, Modifiers};
+use crate::keyboard::{IntoKey, KbKey, KeyEvent, Modifiers, ModifiersExt};
 
 // TODO: fix docstring
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -14,13 +14,7 @@
 
 //! Keyboard types.
 
-// This is a reasonable lint, but we keep signatures in sync with the
-// bitflags implementation of the inner Modifiers type.
-#![allow(clippy::trivially_copy_pass_by_ref)]
-
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
-
-pub use keyboard_types::{Code, KeyState, Location};
+pub use keyboard_types::{Code, KeyState, Location, Modifiers};
 
 /// The meaning (mapped value) of a keypress.
 pub type KbKey = keyboard_types::Key;
@@ -50,16 +44,6 @@ pub struct KeyEvent {
     /// and instead composition events should be used.
     pub is_composing: bool,
 }
-
-/// The modifiers.
-///
-/// This type is a thin wrappers around [`keyboard_types::Modifiers`],
-/// mostly for the convenience methods. If those get upstreamed, it
-/// will simply become that type.
-///
-/// [`keyboard_types::Modifiers`]: keyboard_types::Modifiers
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
-pub struct Modifiers(keyboard_types::Modifiers);
 
 /// A convenience trait for creating Key objects.
 ///
@@ -91,120 +75,36 @@ impl KeyEvent {
     }
 }
 
-impl Modifiers {
-    pub const ALT: Modifiers = Modifiers(keyboard_types::Modifiers::ALT);
-    pub const ALT_GRAPH: Modifiers = Modifiers(keyboard_types::Modifiers::ALT_GRAPH);
-    pub const CAPS_LOCK: Modifiers = Modifiers(keyboard_types::Modifiers::CAPS_LOCK);
-    pub const CONTROL: Modifiers = Modifiers(keyboard_types::Modifiers::CONTROL);
-    pub const FN: Modifiers = Modifiers(keyboard_types::Modifiers::FN);
-    pub const FN_LOCK: Modifiers = Modifiers(keyboard_types::Modifiers::FN_LOCK);
-    pub const META: Modifiers = Modifiers(keyboard_types::Modifiers::META);
-    pub const NUM_LOCK: Modifiers = Modifiers(keyboard_types::Modifiers::NUM_LOCK);
-    pub const SCROLL_LOCK: Modifiers = Modifiers(keyboard_types::Modifiers::SCROLL_LOCK);
-    pub const SHIFT: Modifiers = Modifiers(keyboard_types::Modifiers::SHIFT);
-    pub const SYMBOL: Modifiers = Modifiers(keyboard_types::Modifiers::SYMBOL);
-    pub const SYMBOL_LOCK: Modifiers = Modifiers(keyboard_types::Modifiers::SYMBOL_LOCK);
-    pub const HYPER: Modifiers = Modifiers(keyboard_types::Modifiers::HYPER);
-    pub const SUPER: Modifiers = Modifiers(keyboard_types::Modifiers::SUPER);
-
-    /// Get the inner value.
-    ///
-    /// Note that this function might go away if our changes are upstreamed.
-    pub fn raw(&self) -> keyboard_types::Modifiers {
-        self.0
-    }
-
+/// Extension methods for [`Modifiers`].
+pub trait ModifiersExt {
     /// Determine whether Shift is set.
-    pub fn shift(&self) -> bool {
+    fn shift(&self) -> bool;
+
+    /// Determine whether Ctrl is set.
+    fn ctrl(&self) -> bool;
+
+    /// Determine whether Alt is set.
+    fn alt(&self) -> bool;
+
+    /// Determine whether Meta is set.
+    fn meta(&self) -> bool;
+}
+
+impl ModifiersExt for Modifiers {
+    fn shift(&self) -> bool {
         self.contains(Modifiers::SHIFT)
     }
 
-    /// Determine whether Ctrl is set.
-    pub fn ctrl(&self) -> bool {
+    fn ctrl(&self) -> bool {
         self.contains(Modifiers::CONTROL)
     }
 
-    /// Determine whether Alt is set.
-    pub fn alt(&self) -> bool {
+    fn alt(&self) -> bool {
         self.contains(Modifiers::ALT)
     }
 
-    /// Determine whether Meta is set.
-    pub fn meta(&self) -> bool {
+    fn meta(&self) -> bool {
         self.contains(Modifiers::META)
-    }
-
-    /// Returns an empty set of modifiers.
-    pub fn empty() -> Modifiers {
-        Default::default()
-    }
-
-    /// Returns `true` if no modifiers are set.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Returns `true` if all the modifiers in `other` are set.
-    pub fn contains(&self, other: Modifiers) -> bool {
-        self.0.contains(other.0)
-    }
-
-    /// Inserts or removes the specified modifiers depending on the passed value.
-    pub fn set(&mut self, other: Modifiers, value: bool) {
-        self.0.set(other.0, value)
-    }
-}
-
-impl BitAnd for Modifiers {
-    type Output = Self;
-
-    fn bitand(self, rhs: Self) -> Self {
-        Modifiers(self.0 & rhs.0)
-    }
-}
-
-impl BitAndAssign for Modifiers {
-    // rhs is the "right-hand side" of the expression `a &= b`
-    fn bitand_assign(&mut self, rhs: Self) {
-        *self = Modifiers(self.0 & rhs.0)
-    }
-}
-
-impl BitOr for Modifiers {
-    type Output = Self;
-
-    fn bitor(self, rhs: Self) -> Self {
-        Modifiers(self.0 | rhs.0)
-    }
-}
-
-impl BitOrAssign for Modifiers {
-    // rhs is the "right-hand side" of the expression `a &= b`
-    fn bitor_assign(&mut self, rhs: Self) {
-        *self = Modifiers(self.0 | rhs.0)
-    }
-}
-
-impl BitXor for Modifiers {
-    type Output = Self;
-
-    fn bitxor(self, rhs: Self) -> Self {
-        Modifiers(self.0 ^ rhs.0)
-    }
-}
-
-impl BitXorAssign for Modifiers {
-    // rhs is the "right-hand side" of the expression `a &= b`
-    fn bitxor_assign(&mut self, rhs: Self) {
-        *self = Modifiers(self.0 ^ rhs.0)
-    }
-}
-
-impl Not for Modifiers {
-    type Output = Self;
-
-    fn not(self) -> Self {
-        Modifiers(!self.0)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub use common_util::Counter;
 pub use dialog::{FileDialogOptions, FileInfo, FileSpec};
 pub use error::Error;
 pub use hotkey::{HotKey, RawMods, SysMods};
-pub use keyboard::{Code, IntoKey, KbKey, KeyEvent, KeyState, Location, Modifiers};
+pub use keyboard::{Code, IntoKey, KbKey, KeyEvent, KeyState, Location, Modifiers, ModifiersExt};
 pub use menu::Menu;
 pub use mouse::{Cursor, CursorDesc};
 pub use pointer::{

--- a/src/text.rs
+++ b/src/text.rs
@@ -101,7 +101,7 @@
 //! `InputHandler` calls are simulated from keypresses on other platforms, which
 //! doesn't allow for IME input, dead keys, etc.
 
-use crate::keyboard::{KbKey, KeyEvent};
+use crate::keyboard::{KbKey, KeyEvent, ModifiersExt};
 use crate::kurbo::{Point, Rect};
 use crate::window::{TextFieldToken, WinHandler};
 use std::borrow::Cow;


### PR DESCRIPTION
This was being wrapped to add a small number of extension methods which can be added via a trait instead.

The resulting code is smaller and makes it clear what is different from the upstream `keyboard_types::Modifiers`.