### PR TITLE
Add Wayland dev package dependency info to `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,16 +124,16 @@ explicit minimum supported rust version, but the latest stable version should
 work.
 
 On Linux and BSD, Glazier also requires `pkg-config` and `clang`,
-and the development packages of `libxkbcommon` and `libxcb`, to be installed.
+and the development packages of `wayland`, `libxkbcommon` and `libxcb`, to be installed.
 Some of the examples require `vulkan-loader`.
 
 Most distributions have `pkg-config` installed by default. To install the remaining packages on Fedora, run
-```
-sudo dnf install clang libxkbcommon-x11-devel libxcb-devel vulkan-loader-devel
+```sh
+sudo dnf install clang wayland-devel libxkbcommon-x11-devel libxcb-devel vulkan-loader-devel
 ```
 To install them on Debian or Ubuntu, run
-```
-sudo apt-get install clang libxkbcommon-x11-dev pkg-config libvulkan-dev
+```sh
+sudo apt-get install pkg-config clang libwayland-dev libxkbcommon-x11-dev libvulkan-dev
 ```
 
 ## Further reading


### PR DESCRIPTION
I just did a fresh Ubuntu 23.04 install and was greeted with the following error when attempting to build with the `wayland` feature:

```
error: failed to run custom build command for `wayland-sys v0.30.1`

Caused by:
  process didn't exit successfully: `/home/strom/Rust/glazier/target/debug/build/wayland-sys-23ce904e0e81cf94/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=WAYLAND_CLIENT_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=WAYLAND_CLIENT_STATIC
  cargo:rerun-if-env-changed=WAYLAND_CLIENT_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

  --- stderr
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS="1" PKG_CONFIG_ALLOW_SYSTEM_LIBS="1" "pkg-config" "--libs" "--cflags" "wayland-client"` did not exit successfully: exit status: 1
  error: could not find system library 'wayland-client' required by the 'wayland-sys' crate

  --- stderr
  Package wayland-client was not found in the pkg-config search path.
  Perhaps you should add the directory containing `wayland-client.pc'
  to the PKG_CONFIG_PATH environment variable
  Package 'wayland-client', required by 'virtual:world', not found
  ', /home/strom/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wayland-sys-0.30.1/build.rs:10:47
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed
```
Doing `apt install libwayland-dev` solved the issue and so this PR adds that info to the readme here. I didn't test Fedora, I just looked up the package name.