### PR TITLE
Migrate to the latest `vello` version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ static_assertions = "1.1.0"
 test-log = { version = "0.2.5", features = ["trace"], default-features = false }
 tracing-subscriber = { version = "0.3.2", features = ["env-filter"] }
 unicode-segmentation = "1.7.0"
-vello = { git = "https://github.com/linebender/vello", rev = "3cb54627de0c1fc40af46429ae67458f07174713" }
+vello = { git = "https://github.com/linebender/vello", rev = "9d7c4f00d8db420337706771a37937e9025e089c" }
 parley = { git = "https://github.com/dfrg/parley", rev = "2371bf4b702ec91edee2d58ffb2d432539580e1e" }
 pollster = "0.3.0"
 wgpu = "0.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,10 +146,10 @@ static_assertions = "1.1.0"
 test-log = { version = "0.2.5", features = ["trace"], default-features = false }
 tracing-subscriber = { version = "0.3.2", features = ["env-filter"] }
 unicode-segmentation = "1.7.0"
-vello = { git = "https://github.com/linebender/vello", rev = "5f59a2e8181a7d01f8753680676dd150b965728b" }
-parley = { git = "https://github.com/dfrg/parley", rev = "e4276b4d1001a050c07121f95ca255c771e9a641" }
+vello = { git = "https://github.com/linebender/vello", rev = "3cb54627de0c1fc40af46429ae67458f07174713" }
+parley = { git = "https://github.com/dfrg/parley", rev = "2371bf4b702ec91edee2d58ffb2d432539580e1e" }
 pollster = "0.3.0"
-wgpu = "0.15.0"
+wgpu = "0.17.0"
 
 [target.'cfg(any(target_os = "freebsd", target_os="linux", target_os="openbsd"))'.build-dependencies]
 bindgen = { version = "0.60.1", optional = true }
@@ -164,7 +164,3 @@ doc-scrape-examples = true
 [[example]]
 name = "accesskit"
 required-features = ["accesskit"]
-
-
-[patch."https://github.com/dfrg/fount"]
-fount = { git = "https://github.com/jneem/fount", rev = "361c76fecf813ebc64d2634d3df7bfb6089c6414" }

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,0 +1,6 @@
+// Copyright 2023 the Glazier Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Common functionality for Glazier examples.
+
+pub mod text;

--- a/examples/common/text.rs
+++ b/examples/common/text.rs
@@ -1,0 +1,54 @@
+// Copyright 2022 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Basic text rendering.
+
+// NOTE for Glazier maintenance: This file is a copy of xilem/src/text.rs.
+
+use parley::Layout;
+use vello::kurbo::Affine;
+use vello::{
+    glyph::{fello::raw::FontRef, GlyphContext},
+    peniko::{Brush, Color},
+    *,
+};
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct ParleyBrush(pub Brush);
+
+impl Default for ParleyBrush {
+    fn default() -> ParleyBrush {
+        ParleyBrush(Brush::Solid(Color::rgb8(0, 0, 0)))
+    }
+}
+
+impl parley::style::Brush for ParleyBrush {}
+
+pub fn render_text(builder: &mut SceneBuilder, transform: Affine, layout: &Layout<ParleyBrush>) {
+    let mut gcx = GlyphContext::new();
+    for line in layout.lines() {
+        for glyph_run in line.glyph_runs() {
+            let mut x = glyph_run.offset();
+            let y = glyph_run.baseline();
+            let run = glyph_run.run();
+            let font = run.font();
+            let font_size = run.font_size();
+            let font_ref = font.as_ref();
+            if let Ok(font_ref) = FontRef::from_index(font_ref.data, font.index()) {
+                let style = glyph_run.style();
+                let vars: [(&str, f32); 0] = [];
+                let mut gp = gcx.new_provider(&font_ref, None, font_size, false, vars);
+                for glyph in glyph_run.glyphs() {
+                    if let Some(fragment) = gp.get(glyph.id, Some(&style.brush.0)) {
+                        let gx = x + glyph.x;
+                        let gy = y - glyph.y;
+                        let xform = Affine::translate((gx as f64, gy as f64))
+                            * Affine::scale_non_uniform(1.0, -1.0);
+                        builder.append(&fragment, Some(transform * xform));
+                    }
+                    x += glyph.advance;
+                }
+            }
+        }
+    }
+}

--- a/examples/edit_text.rs
+++ b/examples/edit_text.rs
@@ -1,3 +1,20 @@
+use std::any::Any;
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::ops::Range;
+use std::rc::Rc;
+
+use parley::FontContext;
+use tracing_subscriber::EnvFilter;
+use unicode_segmentation::GraphemeCursor;
+use vello::util::{RenderContext, RenderSurface};
+use vello::Renderer;
+use vello::{
+    kurbo::{Affine, Point, Rect},
+    peniko::{Brush, Color, Fill},
+    RenderParams, RendererOptions, Scene, SceneBuilder,
+};
+
 use glazier::kurbo::Size;
 use glazier::{
     text::{
@@ -7,22 +24,9 @@ use glazier::{
     Application, KeyEvent, Region, Scalable, TextFieldToken, WinHandler, WindowHandle,
 };
 use glazier::{HotKey, SysMods};
-use parley::{FontContext, Layout};
-use std::any::Any;
-use std::borrow::Cow;
-use std::cell::RefCell;
-use std::ops::Range;
-use std::rc::Rc;
-use tracing_subscriber::EnvFilter;
-use unicode_segmentation::GraphemeCursor;
-use vello::util::{RenderContext, RenderSurface};
-use vello::Renderer;
-use vello::{
-    glyph::{fello::raw::FontRef, GlyphContext},
-    kurbo::{Affine, Point, Rect},
-    peniko::{Brush, Color, Fill},
-    RenderParams, RendererOptions, Scene, SceneBuilder,
-};
+
+mod common;
+use common::text::{self, ParleyBrush};
 
 const WIDTH: usize = 2048;
 const HEIGHT: usize = 1536;
@@ -203,7 +207,7 @@ impl WindowState {
             &rect,
         );
         let doc = self.document.borrow();
-        render_text(&mut sb, Affine::translate((TEXT_X, TEXT_Y)), &doc.layout);
+        text::render_text(&mut sb, Affine::translate((TEXT_X, TEXT_Y)), &doc.layout);
         let selection_start_x =
             parley::layout::Cursor::from_position(&doc.layout, doc.selection.min(), true).offset()
                 as f64
@@ -359,53 +363,6 @@ impl WinHandler for WindowState {
 
     fn as_any(&mut self) -> &mut dyn Any {
         self
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct ParleyBrush(pub Brush);
-
-impl Default for ParleyBrush {
-    fn default() -> ParleyBrush {
-        ParleyBrush(Brush::Solid(Color::rgb8(0, 0, 0)))
-    }
-}
-
-impl PartialEq<ParleyBrush> for ParleyBrush {
-    fn eq(&self, _other: &ParleyBrush) -> bool {
-        true // FIXME
-    }
-}
-
-impl parley::style::Brush for ParleyBrush {}
-
-// NOTE for Glazier maintenance: If this function needs an update, keep in mind that this is copied from xilem/src/text.rs.
-pub fn render_text(builder: &mut SceneBuilder, transform: Affine, layout: &Layout<ParleyBrush>) {
-    let mut gcx = GlyphContext::new();
-    for line in layout.lines() {
-        for glyph_run in line.glyph_runs() {
-            let mut x = glyph_run.offset();
-            let y = glyph_run.baseline();
-            let run = glyph_run.run();
-            let font = run.font();
-            let font_size = run.font_size();
-            let font_ref = font.as_ref();
-            if let Ok(font_ref) = FontRef::from_index(font_ref.data, font.index()) {
-                let style = glyph_run.style();
-                let vars: [(&str, f32); 0] = [];
-                let mut gp = gcx.new_provider(&font_ref, None, font_size, false, vars);
-                for glyph in glyph_run.glyphs() {
-                    if let Some(fragment) = gp.get(glyph.id, Some(&style.brush.0)) {
-                        let gx = x + glyph.x;
-                        let gy = y - glyph.y;
-                        let xform = Affine::translate((gx as f64, gy as f64))
-                            * Affine::scale_non_uniform(1.0, -1.0);
-                        builder.append(&fragment, Some(transform * xform));
-                    }
-                    x += glyph.advance;
-                }
-            }
-        }
     }
 }
 

--- a/examples/pen.rs
+++ b/examples/pen.rs
@@ -1,20 +1,20 @@
+use std::any::Any;
+use std::collections::HashMap;
+use std::f64::consts::PI;
+
+use kurbo::Ellipse;
+use vello::util::{RenderContext, RenderSurface};
+use vello::Renderer;
+use vello::{
+    kurbo::{Affine, BezPath, Point, Rect},
+    peniko::{Brush, Color, Fill, Stroke},
+    RenderParams, RendererOptions, Scene, SceneBuilder,
+};
+
 use glazier::kurbo::Size;
 use glazier::{
     Application, Cursor, FileDialogToken, FileInfo, IdleToken, KeyEvent, PenInclination,
     PointerEvent, PointerId, PointerType, Region, Scalable, TimerToken, WinHandler, WindowHandle,
-};
-use kurbo::Ellipse;
-use parley::Layout;
-use std::any::Any;
-use std::collections::HashMap;
-use std::f64::consts::PI;
-use vello::util::{RenderContext, RenderSurface};
-use vello::Renderer;
-use vello::{
-    glyph::{fello::raw::FontRef, GlyphContext},
-    kurbo::{Affine, BezPath, Point, Rect},
-    peniko::{Brush, Color, Fill, Stroke},
-    RenderParams, RendererOptions, Scene, SceneBuilder,
 };
 
 const WIDTH: usize = 2048;
@@ -239,47 +239,6 @@ impl WinHandler for WindowState {
 
     fn as_any(&mut self) -> &mut dyn Any {
         self
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct ParleyBrush(pub Brush);
-
-impl Default for ParleyBrush {
-    fn default() -> ParleyBrush {
-        ParleyBrush(Brush::Solid(Color::rgb8(0, 0, 0)))
-    }
-}
-
-impl parley::style::Brush for ParleyBrush {}
-
-// NOTE for Glazier maintenance: If this function needs an update, keep in mind that this is copied from xilem/src/text.rs.
-pub fn render_text(builder: &mut SceneBuilder, transform: Affine, layout: &Layout<ParleyBrush>) {
-    let mut gcx = GlyphContext::new();
-    for line in layout.lines() {
-        for glyph_run in line.glyph_runs() {
-            let mut x = glyph_run.offset();
-            let y = glyph_run.baseline();
-            let run = glyph_run.run();
-            let font = run.font();
-            let font_size = run.font_size();
-            let font_ref = font.as_ref();
-            if let Ok(font_ref) = FontRef::from_index(font_ref.data, font.index()) {
-                let style = glyph_run.style();
-                let vars: [(&str, f32); 0] = [];
-                let mut gp = gcx.new_provider(&font_ref, None, font_size, false, vars);
-                for glyph in glyph_run.glyphs() {
-                    if let Some(fragment) = gp.get(glyph.id, Some(&style.brush.0)) {
-                        let gx = x + glyph.x;
-                        let gy = y - glyph.y;
-                        let xform = Affine::translate((gx as f64, gy as f64))
-                            * Affine::scale_non_uniform(1.0, -1.0);
-                        builder.append(&fragment, Some(transform * xform));
-                    }
-                    x += glyph.advance;
-                }
-            }
-        }
     }
 }
 

--- a/examples/pen.rs
+++ b/examples/pen.rs
@@ -11,13 +11,10 @@ use std::f64::consts::PI;
 use vello::util::{RenderContext, RenderSurface};
 use vello::Renderer;
 use vello::{
-    glyph::{
-        pinot::{types::Tag, FontRef},
-        GlyphContext,
-    },
+    glyph::{fello::raw::FontRef, GlyphContext},
     kurbo::{Affine, BezPath, Point, Rect},
     peniko::{Brush, Color, Fill, Stroke},
-    Scene, SceneBuilder,
+    RenderParams, RendererOptions, Scene, SceneBuilder,
 };
 
 const WIDTH: usize = 2048;
@@ -95,11 +92,10 @@ impl WindowState {
     fn render(&mut self) {
         let (width, height) = self.surface_size();
         if self.surface.is_none() {
-            self.surface = Some(pollster::block_on(self.render.create_surface(
-                &self.handle,
-                width,
-                height,
-            )));
+            self.surface = Some(
+                pollster::block_on(self.render.create_surface(&self.handle, width, height))
+                    .expect("failed to create surface"),
+            );
         }
 
         render_anim_frame(&mut self.scene, self.pen_state.as_ref(), &self.touch_state);
@@ -112,9 +108,18 @@ impl WindowState {
             let dev_id = surface.dev_id;
             let device = &self.render.devices[dev_id].device;
             let queue = &self.render.devices[dev_id].queue;
+            let renderer_options = RendererOptions {
+                surface_format: Some(surface.format),
+                timestamp_period: queue.get_timestamp_period(),
+            };
+            let render_params = RenderParams {
+                base_color: Color::BLACK,
+                width,
+                height,
+            };
             self.renderer
-                .get_or_insert_with(|| Renderer::new(device).unwrap())
-                .render_to_surface(device, queue, &self.scene, &surface_texture, width, height)
+                .get_or_insert_with(|| Renderer::new(device, &renderer_options).unwrap())
+                .render_to_surface(device, queue, &self.scene, &surface_texture, &render_params)
                 .unwrap();
             surface_texture.present();
         }
@@ -248,6 +253,7 @@ impl Default for ParleyBrush {
 
 impl parley::style::Brush for ParleyBrush {}
 
+// NOTE for Glazier maintenance: If this function needs an update, keep in mind that this is copied from xilem/src/text.rs.
 pub fn render_text(builder: &mut SceneBuilder, transform: Affine, layout: &Layout<ParleyBrush>) {
     let mut gcx = GlyphContext::new();
     for line in layout.lines() {
@@ -255,24 +261,23 @@ pub fn render_text(builder: &mut SceneBuilder, transform: Affine, layout: &Layou
             let mut x = glyph_run.offset();
             let y = glyph_run.baseline();
             let run = glyph_run.run();
-            let font = run.font().as_ref();
+            let font = run.font();
             let font_size = run.font_size();
-            let font_ref = FontRef {
-                data: font.data,
-                offset: font.offset,
-            };
-            let style = glyph_run.style();
-            let vars: [(Tag, f32); 0] = [];
-            let mut gp = gcx.new_provider(&font_ref, None, font_size, false, vars);
-            for glyph in glyph_run.glyphs() {
-                if let Some(fragment) = gp.get(glyph.id, Some(&style.brush.0)) {
-                    let gx = x + glyph.x;
-                    let gy = y - glyph.y;
-                    let xform = Affine::translate((gx as f64, gy as f64))
-                        * Affine::scale_non_uniform(1.0, -1.0);
-                    builder.append(&fragment, Some(transform * xform));
+            let font_ref = font.as_ref();
+            if let Ok(font_ref) = FontRef::from_index(font_ref.data, font.index()) {
+                let style = glyph_run.style();
+                let vars: [(&str, f32); 0] = [];
+                let mut gp = gcx.new_provider(&font_ref, None, font_size, false, vars);
+                for glyph in glyph_run.glyphs() {
+                    if let Some(fragment) = gp.get(glyph.id, Some(&style.brush.0)) {
+                        let gx = x + glyph.x;
+                        let gy = y - glyph.y;
+                        let xform = Affine::translate((gx as f64, gy as f64))
+                            * Affine::scale_non_uniform(1.0, -1.0);
+                        builder.append(&fragment, Some(transform * xform));
+                    }
+                    x += glyph.advance;
                 }
-                x += glyph.advance;
             }
         }
     }

--- a/examples/shello.rs
+++ b/examples/shello.rs
@@ -1,19 +1,23 @@
+use std::any::Any;
+
+use parley::FontContext;
+use tracing_subscriber::EnvFilter;
+use vello::util::{RenderContext, RenderSurface};
+use vello::Renderer;
+use vello::{
+    kurbo::{Affine, PathEl, Point, Rect},
+    peniko::{Brush, Color, Fill, Mix, Stroke},
+    RenderParams, RendererOptions, Scene, SceneBuilder,
+};
+
 use glazier::kurbo::Size;
 use glazier::{
     Application, Cursor, FileDialogToken, FileInfo, IdleToken, KeyEvent, PointerEvent, Region,
     Scalable, TimerToken, WinHandler, WindowHandle,
 };
-use parley::{FontContext, Layout};
-use std::any::Any;
-use tracing_subscriber::EnvFilter;
-use vello::util::{RenderContext, RenderSurface};
-use vello::Renderer;
-use vello::{
-    glyph::{fello::raw::FontRef, GlyphContext},
-    kurbo::{Affine, PathEl, Point, Rect},
-    peniko::{Brush, Color, Fill, Mix, Stroke},
-    RenderParams, RendererOptions, Scene, SceneBuilder,
-};
+
+mod common;
+use common::text::{self, ParleyBrush};
 
 const WIDTH: usize = 2048;
 const HEIGHT: usize = 1536;
@@ -190,53 +194,6 @@ impl WinHandler for WindowState {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct ParleyBrush(pub Brush);
-
-impl Default for ParleyBrush {
-    fn default() -> ParleyBrush {
-        ParleyBrush(Brush::Solid(Color::rgb8(0, 0, 0)))
-    }
-}
-
-impl PartialEq<ParleyBrush> for ParleyBrush {
-    fn eq(&self, _other: &ParleyBrush) -> bool {
-        true // FIXME
-    }
-}
-
-impl parley::style::Brush for ParleyBrush {}
-
-// NOTE for Glazier maintenance: If this function needs an update, keep in mind that this is copied from xilem/src/text.rs.
-pub fn render_text(builder: &mut SceneBuilder, transform: Affine, layout: &Layout<ParleyBrush>) {
-    let mut gcx = GlyphContext::new();
-    for line in layout.lines() {
-        for glyph_run in line.glyph_runs() {
-            let mut x = glyph_run.offset();
-            let y = glyph_run.baseline();
-            let run = glyph_run.run();
-            let font = run.font();
-            let font_size = run.font_size();
-            let font_ref = font.as_ref();
-            if let Ok(font_ref) = FontRef::from_index(font_ref.data, font.index()) {
-                let style = glyph_run.style();
-                let vars: [(&str, f32); 0] = [];
-                let mut gp = gcx.new_provider(&font_ref, None, font_size, false, vars);
-                for glyph in glyph_run.glyphs() {
-                    if let Some(fragment) = gp.get(glyph.id, Some(&style.brush.0)) {
-                        let gx = x + glyph.x;
-                        let gy = y - glyph.y;
-                        let xform = Affine::translate((gx as f64, gy as f64))
-                            * Affine::scale_non_uniform(1.0, -1.0);
-                        builder.append(&fragment, Some(transform * xform));
-                    }
-                    x += glyph.advance;
-                }
-            }
-        }
-    }
-}
-
 pub fn render_anim_frame(scene: &mut Scene, fcx: &mut FontContext, i: u64) {
     let mut sb = SceneBuilder::for_scene(scene);
     let rect = Rect::from_origin_size(Point::new(0.0, 0.0), (1000.0, 1000.0));
@@ -267,7 +224,7 @@ pub fn render_anim_frame(scene: &mut Scene, fcx: &mut FontContext, i: u64) {
     )));
     let mut layout = layout_builder.build();
     layout.break_all_lines(None, parley::layout::Alignment::Start);
-    render_text(&mut sb, Affine::translate((100.0, 400.0)), &layout);
+    text::render_text(&mut sb, Affine::translate((100.0, 400.0)), &layout);
 
     let th = (std::f64::consts::PI / 180.0) * (i as f64);
     let center = Point::new(500.0, 500.0);

--- a/examples/shello.rs
+++ b/examples/shello.rs
@@ -9,13 +9,10 @@ use tracing_subscriber::EnvFilter;
 use vello::util::{RenderContext, RenderSurface};
 use vello::Renderer;
 use vello::{
-    glyph::{
-        pinot::{types::Tag, FontRef},
-        GlyphContext,
-    },
+    glyph::{fello::raw::FontRef, GlyphContext},
     kurbo::{Affine, PathEl, Point, Rect},
     peniko::{Brush, Color, Fill, Mix, Stroke},
-    Scene, SceneBuilder,
+    RenderParams, RendererOptions, Scene, SceneBuilder,
 };
 
 const WIDTH: usize = 2048;
@@ -78,11 +75,10 @@ impl WindowState {
     fn render(&mut self) {
         let (width, height) = self.surface_size();
         if self.surface.is_none() {
-            self.surface = Some(pollster::block_on(self.render.create_surface(
-                &self.handle,
-                width,
-                height,
-            )));
+            self.surface = Some(
+                pollster::block_on(self.render.create_surface(&self.handle, width, height))
+                    .expect("failed to create surface"),
+            );
         }
 
         render_anim_frame(&mut self.scene, &mut self.font_context, self.counter);
@@ -96,9 +92,18 @@ impl WindowState {
             let dev_id = surface.dev_id;
             let device = &self.render.devices[dev_id].device;
             let queue = &self.render.devices[dev_id].queue;
+            let renderer_options = RendererOptions {
+                surface_format: Some(surface.format),
+                timestamp_period: queue.get_timestamp_period(),
+            };
+            let render_params = RenderParams {
+                base_color: Color::BLACK,
+                width,
+                height,
+            };
             self.renderer
-                .get_or_insert_with(|| Renderer::new(device).unwrap())
-                .render_to_surface(device, queue, &self.scene, &surface_texture, width, height)
+                .get_or_insert_with(|| Renderer::new(device, &renderer_options).unwrap())
+                .render_to_surface(device, queue, &self.scene, &surface_texture, &render_params)
                 .unwrap();
             surface_texture.present();
         }
@@ -202,6 +207,7 @@ impl PartialEq<ParleyBrush> for ParleyBrush {
 
 impl parley::style::Brush for ParleyBrush {}
 
+// NOTE for Glazier maintenance: If this function needs an update, keep in mind that this is copied from xilem/src/text.rs.
 pub fn render_text(builder: &mut SceneBuilder, transform: Affine, layout: &Layout<ParleyBrush>) {
     let mut gcx = GlyphContext::new();
     for line in layout.lines() {
@@ -209,24 +215,23 @@ pub fn render_text(builder: &mut SceneBuilder, transform: Affine, layout: &Layou
             let mut x = glyph_run.offset();
             let y = glyph_run.baseline();
             let run = glyph_run.run();
-            let font = run.font().as_ref();
+            let font = run.font();
             let font_size = run.font_size();
-            let font_ref = FontRef {
-                data: font.data,
-                offset: font.offset,
-            };
-            let style = glyph_run.style();
-            let vars: [(Tag, f32); 0] = [];
-            let mut gp = gcx.new_provider(&font_ref, None, font_size, false, vars);
-            for glyph in glyph_run.glyphs() {
-                if let Some(fragment) = gp.get(glyph.id, Some(&style.brush.0)) {
-                    let gx = x + glyph.x;
-                    let gy = y - glyph.y;
-                    let xform = Affine::translate((gx as f64, gy as f64))
-                        * Affine::scale_non_uniform(1.0, -1.0);
-                    builder.append(&fragment, Some(transform * xform));
+            let font_ref = font.as_ref();
+            if let Ok(font_ref) = FontRef::from_index(font_ref.data, font.index()) {
+                let style = glyph_run.style();
+                let vars: [(&str, f32); 0] = [];
+                let mut gp = gcx.new_provider(&font_ref, None, font_size, false, vars);
+                for glyph in glyph_run.glyphs() {
+                    if let Some(fragment) = gp.get(glyph.id, Some(&style.brush.0)) {
+                        let gx = x + glyph.x;
+                        let gy = y - glyph.y;
+                        let xform = Affine::translate((gx as f64, gy as f64))
+                            * Affine::scale_non_uniform(1.0, -1.0);
+                        builder.append(&fragment, Some(transform * xform));
+                    }
+                    x += glyph.advance;
                 }
-                x += glyph.advance;
             }
         }
     }


### PR DESCRIPTION
Vello has moved on to `wgpu` 0.17 and different font handling. This PR brings all of that to the Glazier examples.