### PR TITLE
Fix `PointerButtons` debug formatter.

### DIFF
--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -379,7 +379,7 @@ impl PointerButtons {
 
 impl std::fmt::Debug for PointerButtons {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "PointerButtons({:05b})", self.0 >> 1)
+        write!(f, "PointerButtons({:05b})", self.0)
     }
 }
 


### PR DESCRIPTION
The old `MouseButtons` bitset had funky off-by-one storage. The new `PointerButtons` has more intuitive straight storage. This PR updates the debug formatter to match that new reality.

Easy way to test is with the `shello` example and clicking the primary mouse button. Without this PR it will print all zeroes, with this PR applied it will print correctly.