### PR TITLE
Match the web backend's `set_title` method signature to others.

### DIFF
--- a/src/backend/web/window.rs
+++ b/src/backend/web/window.rs
@@ -722,9 +722,9 @@ impl WindowHandle {
         warn!("show_context_menu unimplemented for web");
     }
 
-    pub fn set_title(&self, title: impl Into<String>) {
+    pub fn set_title(&self, title: &str) {
         if let Some(state) = self.0.upgrade() {
-            state.canvas.set_title(&(title.into()))
+            state.canvas.set_title(title)
         }
     }
 


### PR DESCRIPTION
All other backends and more importantly the cross-platform `WindowHandle::set_title` method takes the title as a `&str`. The web backend ends up using a `&str` too, so the inbetween `String` allocation doesn't make much sense. This PR removes that.