### PR TITLE
deps: Remove direct calloop dep.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,6 @@ x11rb = { version = "0.11.1", features = [
 ], optional = true }
 
 rand = { version = "0.8.0", optional = true }
-calloop = { version = "0.7.1", optional = true }
 log = { version = "0.4.14", optional = true }
 
 # Wayland dependencies


### PR DESCRIPTION
Only wayland code is using `calloop` now and it uses it as a re-export rather than this version here.