### PR TITLE
windows: Use `Rc` with `HCURSOR`.

### DIFF
--- a/src/backend/windows/window.rs
+++ b/src/backend/windows/window.rs
@@ -292,7 +292,7 @@ struct WndState {
 }
 
 #[derive(Clone, PartialEq, Eq)]
-pub struct CustomCursor(Arc<HCursor>);
+pub struct CustomCursor(Rc<HCursor>);
 
 #[derive(PartialEq, Eq)]
 struct HCursor(HCURSOR);
@@ -1962,7 +1962,7 @@ impl WindowHandle {
                 };
                 let icon = CreateIconIndirect(&mut icon_info);
 
-                Some(Cursor::Custom(CustomCursor(Arc::new(HCursor(icon)))))
+                Some(Cursor::Custom(CustomCursor(Rc::new(HCursor(icon)))))
             }
         } else {
             None


### PR DESCRIPTION
The `Cursor` isn't `Send` / `Sync`, so this can just use `Rc`.

Since `HCURSOR` isn't `Send` / `Sync`, it wasn't valid to use `Arc` with it. This generates a clippy warning starting in Rust 1.72.

Fixes #138.