### PR TITLE
Make the CI script more generic and robust.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: install additional linux dependencies
         run: |
           sudo apt update
-          sudo apt install libwayland-dev libxkbcommon-x11-dev libx11-dev libpango1.0-dev
+          sudo apt install libwayland-dev libxkbcommon-x11-dev
         if: contains(matrix.os, 'ubuntu')
 
       - name: install stable toolchain
@@ -108,7 +108,7 @@ jobs:
       - name: install additional linux dependencies
         run: |
           sudo apt update
-          sudo apt install libwayland-dev libxkbcommon-x11-dev libx11-dev libpango1.0-dev
+          sudo apt install libwayland-dev libxkbcommon-x11-dev
         if: contains(matrix.os, 'ubuntu')
 
       - name: install nightly toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: cargo clippy (no default features)
         run: cargo clippy --workspace --all-targets --no-default-features -- -D warnings
+        # No default features means no backend on Linux, so we won't run it
+        if: contains(matrix.os, 'ubuntu') == false
       
       - name: cargo clippy (default features)
         run: cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@
 env:
   RUST_STABLE_VER: "1.71" # In quotes because otherwise 1.70 would be interpreted as 1.7
 
+name: CI
+
 on:
   push:
     branches:
@@ -26,21 +28,21 @@ jobs:
           components: rustfmt
 
       - name: cargo fmt
-        run: cargo fmt --all -- --check
+        run: cargo fmt --all --check
 
   test-stable:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macOS-latest, windows-2019, ubuntu-latest]
-    name: cargo clippy+test
+    name: cargo clippy + test
     steps:
       - uses: actions/checkout@v3
 
-      - name: install libx11-dev
+      - name: install additional linux dependencies
         run: |
           sudo apt update
-          sudo apt install libx11-dev libpango1.0-dev libxkbcommon-dev libxkbcommon-x11-dev
+          sudo apt install libwayland-dev libxkbcommon-x11-dev libx11-dev libpango1.0-dev
         if: contains(matrix.os, 'ubuntu')
 
       - name: install stable toolchain
@@ -52,41 +54,17 @@ jobs:
       - name: restore cache
         uses: Swatinem/rust-cache@v2
 
-      - name: cargo clippy glazier
-        run: cargo clippy --all-targets --features=x11 --no-default-features -- -D warnings
+      - name: cargo clippy (no default features)
+        run: cargo clippy --workspace --all-targets --no-default-features -- -D warnings
+      
+      - name: cargo clippy (default features)
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
-      - name: cargo test glazier
-        run: cargo test --no-default-features --features=x11
+      - name: cargo clippy (all features)
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
-      - name: cargo build accesskit example
-        run: cargo build --features accesskit --example accesskit
-
-  # we test the wayland backend as a separate job
-  test-stable-wayland:
-    runs-on: ubuntu-latest
-    name: cargo clippy+test (wayland)
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: install wayland
-        run: |
-          sudo apt update
-          sudo apt install libwayland-dev libpango1.0-dev libxkbcommon-dev
-
-      - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_STABLE_VER }}
-          components: clippy
-
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: cargo clippy glazier
-        run: cargo clippy --all-targets --features=wayland --no-default-features -- -D warnings
-
-      - name: cargo test glazier
-        run: cargo test --features wayland --no-default-features
+      - name: cargo test
+        run: cargo test --workspace --all-features
 
 #  test-stable-wasm:
 #    runs-on: macOS-latest
@@ -116,95 +94,26 @@ jobs:
 #      - name: cargo test compile glazier
 #        run: cargo test --no-run --target wasm32-unknown-unknown
 
-  doctest-stable:
-    runs-on: macOS-latest
-    name: glazier doctests
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_STABLE_VER }}
-
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: cargo test glazier --doc
-        run: cargo test --doc --no-default-features --features=accesskit
-
-  # This tests the future rust compiler to catch errors ahead of time without
-  # breaking CI
-  # We only run on a single OS to save time; this might let some errors go
-  # undetected until the compiler updates and they break CI; but that should
-  # happen rarely, and not pose too much of a problem when it does.
-  test-beta:
-    runs-on: macOS-latest
-    name: cargo clippy+test beta
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: install beta toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "beta"
-          components: clippy
-
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: cargo clippy glazier
-        run: cargo clippy --all-targets -- -D warnings
-        continue-on-error: true
-
-      - name: cargo test glazier
-        run: cargo test --no-default-features --features=x11
-        continue-on-error: true
-
-  doctest-beta:
-    runs-on: macOS-latest
-    name: glazier doctests beta
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: install beta toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "beta"
-
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: cargo test glazier --doc
-        run: cargo test --doc --features=accesskit
-
-  check-docs:
-    name: Docs
+  docs:
+    name: cargo doc
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, windows-2019]
+        os: [macOS-latest, windows-2019, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
 
-      - name: install dependencies
+      - name: install additional linux dependencies
         run: |
           sudo apt update
-          sudo apt install libxkbcommon-dev libxkbcommon-x11-dev
+          sudo apt install libwayland-dev libxkbcommon-x11-dev libx11-dev libpango1.0-dev
         if: contains(matrix.os, 'ubuntu')
 
-      - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_STABLE_VER }}
+      - name: install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: restore cache
         uses: Swatinem/rust-cache@v2
 
-      - name: cargo doc glazier
-        run: cargo doc --no-deps --document-private-items
-
-      # On Linux also attempt docs for X11.
-      - name: cargo doc glazier (X11)
-        run: cargo doc --features=x11 --no-deps --document-private-items
-        if: contains(matrix.os, 'ubuntu')
+      - name: cargo doc
+        run: cargo doc --workspace --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
-# We aim to always test with the latest stable Rust toolchain, however we pin to a specific version
-# like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still come
-# automatically. If the version specified here is no longer the latest stable version,
-# then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
 env:
+  # We aim to always test with the latest stable Rust toolchain, however we pin to a specific
+  # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
+  # come automatically. If the version specified here is no longer the latest stable version,
+  # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
   RUST_STABLE_VER: "1.71" # In quotes because otherwise 1.70 would be interpreted as 1.7
 
 name: CI
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, windows-2019, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
     name: cargo clippy + test
     steps:
       - uses: actions/checkout@v3
@@ -101,7 +101,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, windows-2019, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["/.github/"]
 publish = false # Until it's ready
 
 [package.metadata.docs.rs]
-features = ["accesskit"] # Try to keep all features enabled for docs
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
 # rustdoc-scrape-examples tracking issue https://github.com/rust-lang/rust/issues/88791

--- a/examples/edit_text.rs
+++ b/examples/edit_text.rs
@@ -4,6 +4,8 @@ use std::cell::RefCell;
 use std::ops::Range;
 use std::rc::Rc;
 
+#[cfg(feature = "accesskit")]
+use accesskit::TreeUpdate;
 use parley::FontContext;
 use tracing_subscriber::EnvFilter;
 use unicode_segmentation::GraphemeCursor;
@@ -279,6 +281,12 @@ impl WinHandler for WindowState {
     fn paint(&mut self, _: &Region) {
         self.render();
         self.schedule_render();
+    }
+
+    #[cfg(feature = "accesskit")]
+    fn accesskit_tree(&mut self) -> TreeUpdate {
+        // TODO: Construct a real TreeUpdate
+        TreeUpdate::default()
     }
 
     fn size(&mut self, size: Size) {

--- a/examples/pen.rs
+++ b/examples/pen.rs
@@ -2,6 +2,8 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::f64::consts::PI;
 
+#[cfg(feature = "accesskit")]
+use accesskit::TreeUpdate;
 use kurbo::Ellipse;
 use vello::util::{RenderContext, RenderSurface};
 use vello::Renderer;
@@ -137,6 +139,12 @@ impl WinHandler for WindowState {
     fn paint(&mut self, _: &Region) {
         self.render();
         self.schedule_render();
+    }
+
+    #[cfg(feature = "accesskit")]
+    fn accesskit_tree(&mut self) -> TreeUpdate {
+        // TODO: Construct a real TreeUpdate
+        TreeUpdate::default()
     }
 
     fn idle(&mut self, _: IdleToken) {

--- a/examples/shello.rs
+++ b/examples/shello.rs
@@ -1,5 +1,7 @@
 use std::any::Any;
 
+#[cfg(feature = "accesskit")]
+use accesskit::TreeUpdate;
 use parley::FontContext;
 use tracing_subscriber::EnvFilter;
 use vello::util::{RenderContext, RenderSurface};
@@ -125,6 +127,12 @@ impl WinHandler for WindowState {
     fn paint(&mut self, _: &Region) {
         self.render();
         self.schedule_render();
+    }
+
+    #[cfg(feature = "accesskit")]
+    fn accesskit_tree(&mut self) -> TreeUpdate {
+        // TODO: Construct a real TreeUpdate
+        TreeUpdate::default()
     }
 
     fn idle(&mut self, _: IdleToken) {}

--- a/examples/wgpu-triangle/main.rs
+++ b/examples/wgpu-triangle/main.rs
@@ -1,6 +1,10 @@
+use std::any::Any;
+
+#[cfg(feature = "accesskit")]
+use accesskit::TreeUpdate;
+
 use glazier::kurbo::Size;
 use glazier::{Application, IdleToken, Region, Scalable, WinHandler, WindowHandle};
-use std::any::Any;
 
 const WIDTH: usize = 2048;
 const HEIGHT: usize = 1536;
@@ -179,6 +183,12 @@ impl WinHandler for WindowState {
         let inner = self.inner.as_mut().unwrap();
         inner.draw();
         inner.schedule_render();
+    }
+
+    #[cfg(feature = "accesskit")]
+    fn accesskit_tree(&mut self) -> TreeUpdate {
+        // TODO: Construct a real TreeUpdate
+        TreeUpdate::default()
     }
 
     fn idle(&mut self, _: IdleToken) {}


### PR DESCRIPTION
As has been noted in #1 the `glazier` CI has been mostly a rough port of the `druid-shell` CI script. Recently, mostly thanks to @waywardmonkeys, our CI scripts have received some improvements. This PR here pushes that forward some more by incorporating some `druid-shell` post-fork changes and also a few other lessons from running the Druid CI over the years.

## Changes
* The script now has a short name, `CI`, instead of the automatic `.github/workflows/ci.yml` to reduce UI noise.
* Everything is more generic, which means the script has e.g. `--workspace` which has no practical effect for Glazier at this point in time. The goal is to have a more easily syncable generic Linebender CI with minimal required changes per repository.
* Wayland no longer receives a separate job and instead gets tested using the general process.

  The original reason why Wayland had its own job for `druid-shell` was because we had GTK, X11, and Wayland to test which meant that the Linux job ran significantly longer than others. With GTK gone that reason has withered. Now the counter argument to have a single Linux job is stronger. Most of the common dependencies are already built for X11 so the additional building needed for Wayland is small. Also this helps reduce the GitHub job cache eviction pressure by no longer saving ~430MB per Wayland test run of essentially duplicate artifacts.
* Removed `libx11-dev` & `libpango1.0-dev` from the dependency setup. The former is preinstalled already, the latter is no longer required.
* Updated `windows-2019` to `windows-latest` which currently translates to `windows-2022`.
* Run `clippy` with no default features, then default features, then all features. This doesn't have too much of an impact on time spent, because the follow-up stages can reuse most dependencies that were built in an earlier stage.

  As for motivation, imagine a scenario where `glazier` depends on `lib_a` and optionally on `lib_b`. Glazier code using `feat_a` of `lib_a` works fine, because `lib_b` enables `lib_a::feat_a`. However when `lib_b` is no longer included, code unexpectedly breaks. This has happened in practice with Druid and so doing more granular feature testing helps avoid it. Of course in a perfect world we would test every feature combination. However for regular CI I think starting with these three options should help catch most cases.
* Removed beta toolchain jobs. The original motivation for these was to catch `clippy` errors early before they hit stable. Now  that #76 is merged and the strategy is to explicitly update the toolchain version, there won't be any sudden breakage that these beta jobs were meant to combat. So we can just remove them.
* Documentation code tests no longer have a separate job and are instead run as part of the general testing path.
* Documentation itself is generated using the nightly toolchain, because that is [what docs.rs uses](https://docs.rs/about/builds). This is another learned lesson from Druid where docs were fine with the stable toolchain, but then after publishing the crate the online docs were broken. Best to catch that earlier.
* Added back doc generation tests for Linux.

---
Fixes #1