### PR TITLE
Support timers on Wayland

### DIFF
--- a/src/backend/wayland/application.rs
+++ b/src/backend/wayland/application.rs
@@ -26,7 +26,7 @@ use smithay_client_toolkit::{
     compositor::CompositorState,
     output::OutputState,
     reexports::{
-        calloop::{channel, EventLoop, LoopSignal},
+        calloop::{channel, EventLoop, LoopHandle, LoopSignal},
         client::{
             globals::{registry_queue_init, BindError},
             protocol::wl_compositor,
@@ -57,6 +57,7 @@ pub struct Application {
     pub(super) wayland_queue: QueueHandle<WaylandState>,
     pub(super) xdg_shell: Weak<XdgShell>,
     loop_signal: LoopSignal,
+    pub(super) loop_handle: LoopHandle<'static, WaylandState>,
     pub(super) idle_sender: Sender<IdleAction>,
     pub(super) loop_sender: channel::Sender<ActiveAction>,
     pub(super) raw_display_handle: *mut c_void,
@@ -126,7 +127,7 @@ impl Application {
             seats: SeatState::new(&globals, &qh),
             xkb_context: Context::new(),
             text_input: text_input_global,
-            loop_handle,
+            loop_handle: loop_handle.clone(),
         };
         state.initial_seats();
         Ok(Application {
@@ -136,6 +137,7 @@ impl Application {
             loop_signal,
             idle_sender,
             loop_sender,
+            loop_handle,
             xdg_shell: shell_ref,
             raw_display_handle: conn.backend().display_ptr().cast(),
         })

--- a/src/backend/wayland/window.rs
+++ b/src/backend/wayland/window.rs
@@ -264,7 +264,7 @@ impl WindowHandle {
                     TimeoutAction::Drop
                 },
             )
-            .expect("could add a timer loop");
+            .expect("adding a Timer to the calloop event loop is infallible");
         token
     }
 


### PR DESCRIPTION
This was luckily really simple.

I've also added support for a blinking cursor to the edit_text example, to test out this functionality.

Reporting when/how to blink the cursor is a bit of an open question at the moment - it could even be the responsibility of the IME (via the input lock system?). But that can be improved later