### PR TITLE
Fix Windows build.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ features = [
     "fileapi",
     "processenv",
     "winbase",
+    "winerror",
     "handleapi",
     "winnls",
 ]


### PR DESCRIPTION
For some reason, this passed CI but is actually broken and needs `winerror` feature enabled. This was previously transitively enabled by `dwrite` and probably other features, but we removed the `dwrite` feature.