### PR TITLE
Split CI `clippy` into main & auxiliary steps.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ env:
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
   RUST_STABLE_VER: "1.71" # In quotes because otherwise 1.70 would be interpreted as 1.7
 
+# Rationale
+#
+# We don't run clippy with --all-targets because then even --lib and --bins are compiled with
+# dev dependencies enabled, which does not match how they would be compiled by users.
+# A dev dependency might enable a feature of a regular dependency that we need, but testing
+# with --all-targets would not catch that. Thus we split --lib & --bins into a separate step.
+
 name: CI
 
 on:
@@ -55,15 +62,26 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: cargo clippy (no default features)
-        run: cargo clippy --workspace --all-targets --no-default-features -- -D warnings
+        run: cargo clippy --workspace --lib --bins --no-default-features -- -D warnings
         # No default features means no backend on Linux, so we won't run it
         if: contains(matrix.os, 'ubuntu') == false
-      
+
+      - name: cargo clippy (no default features) (auxiliary)
+        run: cargo clippy --workspace --tests --benches --examples --no-default-features -- -D warnings
+        # No default features means no backend on Linux, so we won't run it
+        if: contains(matrix.os, 'ubuntu') == false
+
       - name: cargo clippy (default features)
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --lib --bins -- -D warnings
+
+      - name: cargo clippy (default features) (auxiliary)
+        run: cargo clippy --workspace --tests --benches --examples -- -D warnings
 
       - name: cargo clippy (all features)
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --lib --bins --all-features -- -D warnings
+
+      - name: cargo clippy (all features) (auxiliary)
+        run: cargo clippy --workspace --tests --benches --examples --all-features -- -D warnings
 
       - name: cargo test
         run: cargo test --workspace --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ env:
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ features = [
     "fileapi",
     "processenv",
     "winbase",
-    #"winerror",
+    "winerror",
     "handleapi",
     "winnls",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ features = [
     "fileapi",
     "processenv",
     "winbase",
-    "winerror",
+    #"winerror",
     "handleapi",
     "winnls",
 ]


### PR DESCRIPTION
We ran into an interesting situation with #151 where the CI succeeded despite our `Cargo.toml` not correctly specifying the `winerror` feature for `winapi`. --- ( _`Cargo.toml` was fixed by #153._ )

This happened because some of our dev dependencies enable the `winerror` feature of `winapi`. This can be seen by comparing `cargo tree -e features` vs `cargo tree -e features -e no-dev`.

Looking deeper, this happened because `cargo` builds with dev dependencies if any of `--tests` / `--benches` / `--examples` are enabled. This was always the case for us, as we either did `cargo test` or `cargo clippy --all-targets`.

This issue has bitten us before too, just this year. Back in April we received a bug report for Druid ([druid#2373](https://github.com/linebender/druid/issues/2373)) that a simple hello world type app won't compile. The same story there, the CI always ran with dev dependencies enabled. I concluded back then: _Seems like a shortcoming of our testing methodology that it always builds with dev dependencies. Something to look into._ Looking into it is probably somewhere in my mountain of todo tasks but obviously I didn't get to it fast enough for the issue to not repeat.

This PR here addresses that shortcoming. We split `clippy` into two steps. That is, `--all-targets` becomes `--lib --bins` and also `--tests --benches --examples`. This will increase the CI runtime a bit but there's just no way around that. Tests require dev dependencies, however we don't want those enabled for the main checks.

