### PR TITLE
windows: Fix not linking against shell32 lib.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ features = [
     "winbase",
     "winerror",
     "handleapi",
+    "shellapi",
     "winnls",
 ]
 


### PR DESCRIPTION
Fixes #156.