### PR TITLE
deps: Update `keyboard-types` to 0.7.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ lazy_static = "1.4.0"
 cfg-if = "1.0.0"
 instant = { version = "0.1.6", features = ["wasm-bindgen"] }
 anyhow = "1.0.32"
-keyboard-types = { version = "0.6.2", default_features = false }
+keyboard-types = { version = "0.7", default_features = false }
 memchr = "2.5"
 
 # Optional dependencies

--- a/src/backend/mac/menu.rs
+++ b/src/backend/mac/menu.rs
@@ -22,7 +22,7 @@ use objc::{msg_send, sel, sel_impl};
 use super::util::make_nsstring;
 use crate::common_util::strip_access_key;
 use crate::hotkey::HotKey;
-use crate::keyboard::{KbKey, Modifiers, ModifiersExt};
+use crate::keyboard::{KbKey, Modifiers};
 
 pub struct Menu {
     pub menu: id,

--- a/src/backend/windows/keyboard.rs
+++ b/src/backend/windows/keyboard.rs
@@ -20,7 +20,7 @@ use std::convert::TryInto;
 use std::mem;
 use std::ops::RangeInclusive;
 
-use crate::keyboard::{Code, KbKey, KeyEvent, KeyState, Location, Modifiers, ModifiersExt};
+use crate::keyboard::{Code, KbKey, KeyEvent, KeyState, Location, Modifiers};
 
 use winapi::shared::minwindef::{HKL, INT, LPARAM, UINT, WPARAM};
 use winapi::shared::ntdef::SHORT;

--- a/src/backend/windows/menu.rs
+++ b/src/backend/windows/menu.rs
@@ -25,7 +25,7 @@ use winapi::um::winuser::*;
 
 use super::util::ToWide;
 use crate::hotkey::HotKey;
-use crate::keyboard::{KbKey, Modifiers, ModifiersExt};
+use crate::keyboard::{KbKey, Modifiers};
 
 /// A menu object, which can be either a top-level menubar or a
 /// submenu.

--- a/src/backend/windows/window.rs
+++ b/src/backend/windows/window.rs
@@ -62,7 +62,7 @@ use super::util::{self, ToWide, OPTIONAL_FUNCTIONS};
 use crate::common_util::IdleCallback;
 use crate::dialog::{FileDialogOptions, FileDialogType, FileInfo};
 use crate::error::Error as ShellError;
-use crate::keyboard::{KbKey, KeyState, ModifiersExt};
+use crate::keyboard::{KbKey, KeyState};
 use crate::mouse::{Cursor, CursorDesc};
 use crate::pointer::{
     MouseInfo, PointerButton, PointerButtons, PointerEvent, PointerId, PointerType,

--- a/src/backend/x11/window.rs
+++ b/src/backend/x11/window.rs
@@ -52,7 +52,7 @@ use crate::backend::shared::Timer;
 use crate::common_util::IdleCallback;
 use crate::dialog::FileDialogOptions;
 use crate::error::Error as ShellError;
-use crate::keyboard::{KeyState, Modifiers, ModifiersExt};
+use crate::keyboard::{KeyState, Modifiers};
 use crate::kurbo::{Insets, Point, Rect, Size, Vec2};
 use crate::mouse::{Cursor, CursorDesc};
 use crate::region::Region;

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -18,7 +18,7 @@ use std::borrow::Borrow;
 
 use tracing::warn;
 
-use crate::keyboard::{IntoKey, KbKey, KeyEvent, Modifiers, ModifiersExt};
+use crate::keyboard::{IntoKey, KbKey, KeyEvent, Modifiers};
 
 // TODO: fix docstring
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -75,39 +75,6 @@ impl KeyEvent {
     }
 }
 
-/// Extension methods for [`Modifiers`].
-pub trait ModifiersExt {
-    /// Determine whether Shift is set.
-    fn shift(&self) -> bool;
-
-    /// Determine whether Ctrl is set.
-    fn ctrl(&self) -> bool;
-
-    /// Determine whether Alt is set.
-    fn alt(&self) -> bool;
-
-    /// Determine whether Meta is set.
-    fn meta(&self) -> bool;
-}
-
-impl ModifiersExt for Modifiers {
-    fn shift(&self) -> bool {
-        self.contains(Modifiers::SHIFT)
-    }
-
-    fn ctrl(&self) -> bool {
-        self.contains(Modifiers::CONTROL)
-    }
-
-    fn alt(&self) -> bool {
-        self.contains(Modifiers::ALT)
-    }
-
-    fn meta(&self) -> bool {
-        self.contains(Modifiers::META)
-    }
-}
-
 impl IntoKey for KbKey {
     fn into_key(self) -> KbKey {
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub use common_util::Counter;
 pub use dialog::{FileDialogOptions, FileInfo, FileSpec};
 pub use error::Error;
 pub use hotkey::{HotKey, RawMods, SysMods};
-pub use keyboard::{Code, IntoKey, KbKey, KeyEvent, KeyState, Location, Modifiers, ModifiersExt};
+pub use keyboard::{Code, IntoKey, KbKey, KeyEvent, KeyState, Location, Modifiers};
 pub use menu::Menu;
 pub use mouse::{Cursor, CursorDesc};
 pub use pointer::{

--- a/src/text.rs
+++ b/src/text.rs
@@ -101,7 +101,7 @@
 //! `InputHandler` calls are simulated from keypresses on other platforms, which
 //! doesn't allow for IME input, dead keys, etc.
 
-use crate::keyboard::{KbKey, KeyEvent, ModifiersExt};
+use crate::keyboard::{KbKey, KeyEvent};
 use crate::kurbo::{Point, Rect};
 use crate::window::{TextFieldToken, WinHandler};
 use std::borrow::Cow;


### PR DESCRIPTION
This lets us remove our `ModifiersExt` now that that functionality is available in the upstream release.