### PR TITLE
Remove `serde` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,6 @@ wayland = [
     "wayland-backend",
 ]
 
-serde = ["kurbo/serde"]
-
 accesskit = [
     "dep:accesskit",
     "accesskit_macos",


### PR DESCRIPTION
This only enabled `serde` within `kurbo`, but this crate doesn't actually use `serde` at all.

If a dependant crate wants `serde` enabled in `kurbo`, they would already be using `kurbo` and can enable it on their own.

This was added in 080a094b1e70bd7a6194522b3d336e8c9a91e7ee but with no indication in the commit as to why it was needed. This was in 2021, so it pre-dates the `glazier` efforts.