### PR TITLE
Wayland: connect in configure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-target = "x86_64-pc-windows-msvc"
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [features]
-default = ["x11", "wayland"]
+default = ["x11"]
 x11 = ["ashpd", "bindgen", "futures", "nix", "pkg-config", "x11rb"]
 wayland = [
     # Required for XKBCommon

--- a/src/backend/wayland/window.rs
+++ b/src/backend/wayland/window.rs
@@ -712,6 +712,13 @@ impl WaylandWindowState {
             if matches!(context, PaintContext::Frame) {
                 props.pending_frame_callback = false;
             }
+            if matches!(context, PaintContext::Requested) && props.pending_frame_callback && !force
+            {
+                // We'll handle this in the frame callback, when that occurs.
+                // This ensures throttling is respected
+                // This also prevents a hang on startup, although the reason for that occuring isn't clear
+                return;
+            }
             if !props.configured || (!props.will_repaint && !force) {
                 return;
             }


### PR DESCRIPTION
This should resolve an issue Lapce is having on the Wayland backend. There is an unexplained hang I've discovered, but the workaround I've also implemented is a correctness improvement which incidentally appears to address that hang?

See [#glazier > Freeze with Wayland egl](https://xi.zulipchat.com/#narrow/stream/351333-glazier/topic/Freeze.20with.20Wayland.20egl).

I've also disabled the wayland backend by default again, as it was inadvertently enabled in #119. I would like us to expose the Wayland feature up the stack all the way to Lapce (cc @waywardmonkeys), so that testing can occur directly on main Lapce without patches