### PR TITLE
Pass PointerEvent/ KeyEvent by ref.

### DIFF
--- a/examples/accesskit.rs
+++ b/examples/accesskit.rs
@@ -167,7 +167,7 @@ impl WinHandler for HelloState {
         }
     }
 
-    fn key_down(&mut self, event: KeyEvent) -> bool {
+    fn key_down(&mut self, event: &KeyEvent) -> bool {
         if event.key == KbKey::Tab {
             self.focus = if self.focus == CHECKBOX_1_ID {
                 CHECKBOX_2_ID

--- a/examples/edit_text.rs
+++ b/examples/edit_text.rs
@@ -366,16 +366,16 @@ impl WinHandler for WindowState {
         self.cursor_blink_token = Some(self.handle.request_timer(CURSOR_BLINK_INTERVAL));
     }
 
-    fn key_down(&mut self, event: KeyEvent) -> bool {
+    fn key_down(&mut self, event: &KeyEvent) -> bool {
         self.schedule_render();
-        if self.hotkeys.copy.matches(&event) {
+        if self.hotkeys.copy.matches(event) {
             let doc = self.document.borrow_mut();
             let text = &doc.text[doc.selection.range()];
             Application::global().clipboard().put_string(text); // return true prevents the keypress event from being handled as text input
 
             return true;
         }
-        if self.hotkeys.paste.matches(&event) {
+        if self.hotkeys.paste.matches(event) {
             println!("Pasting");
             let clipboard_contents = Application::global().clipboard().get_string();
             if let Some(mut contents) = clipboard_contents {
@@ -399,7 +399,7 @@ impl WinHandler for WindowState {
 
             return true;
         }
-        if self.hotkeys.select_all.matches(&event) {
+        if self.hotkeys.select_all.matches(event) {
             {
                 let mut doc = self.document.borrow_mut();
                 doc.selection = Selection::new(0, doc.text.len());

--- a/examples/pen.rs
+++ b/examples/pen.rs
@@ -162,20 +162,20 @@ impl WinHandler for WindowState {
         println!("save file result: {file:?}");
     }
 
-    fn key_down(&mut self, event: KeyEvent) -> bool {
+    fn key_down(&mut self, event: &KeyEvent) -> bool {
         println!("keydown: {event:?}");
         false
     }
 
-    fn key_up(&mut self, event: KeyEvent) {
+    fn key_up(&mut self, event: &KeyEvent) {
         println!("keyup: {event:?}");
     }
 
-    fn wheel(&mut self, event: PointerEvent) {
+    fn wheel(&mut self, event: &PointerEvent) {
         println!("wheel {event:?}");
     }
 
-    fn pointer_move(&mut self, event: PointerEvent) {
+    fn pointer_move(&mut self, event: &PointerEvent) {
         self.handle.set_cursor(&Cursor::Arrow);
         match &event.pointer_type {
             PointerType::Pen(info) => {
@@ -196,7 +196,7 @@ impl WinHandler for WindowState {
         }
     }
 
-    fn pointer_down(&mut self, event: PointerEvent) {
+    fn pointer_down(&mut self, event: &PointerEvent) {
         if let PointerType::Touch(_) = &event.pointer_type {
             let color = if event.is_primary {
                 Color::RED
@@ -211,7 +211,7 @@ impl WinHandler for WindowState {
         }
     }
 
-    fn pointer_up(&mut self, event: PointerEvent) {
+    fn pointer_up(&mut self, event: &PointerEvent) {
         if let PointerType::Touch(_) = &event.pointer_type {
             self.touch_state.points.remove(&event.pointer_id);
         }

--- a/examples/shello.rs
+++ b/examples/shello.rs
@@ -147,29 +147,29 @@ impl WinHandler for WindowState {
         println!("save file result: {file:?}");
     }
 
-    fn key_down(&mut self, event: KeyEvent) -> bool {
+    fn key_down(&mut self, event: &KeyEvent) -> bool {
         println!("keydown: {event:?}");
         false
     }
 
-    fn key_up(&mut self, event: KeyEvent) {
+    fn key_up(&mut self, event: &KeyEvent) {
         println!("keyup: {event:?}");
     }
 
-    fn wheel(&mut self, event: PointerEvent) {
+    fn wheel(&mut self, event: &PointerEvent) {
         println!("wheel {event:?}");
     }
 
-    fn pointer_move(&mut self, _event: PointerEvent) {
+    fn pointer_move(&mut self, _event: &PointerEvent) {
         self.handle.set_cursor(&Cursor::Arrow);
         //println!("pointer_move {event:?}");
     }
 
-    fn pointer_down(&mut self, event: PointerEvent) {
+    fn pointer_down(&mut self, event: &PointerEvent) {
         println!("pointer_down {event:?}");
     }
 
-    fn pointer_up(&mut self, event: PointerEvent) {
+    fn pointer_up(&mut self, event: &PointerEvent) {
         println!("pointer_up {event:?}");
     }
 

--- a/src/backend/mac/window.rs
+++ b/src/backend/mac/window.rs
@@ -797,7 +797,7 @@ fn mouse_down(this: &mut Object, nsevent: id, button: PointerButton) {
         let count = nsevent.clickCount() as u8;
         let focus = view_state.focus_click && button == PointerButton::Primary;
         let event = mouse_pointer_event(nsevent, this as id, count, focus, button, Vec2::ZERO);
-        view_state.handler.pointer_down(event);
+        view_state.handler.pointer_down(&event);
     }
 }
 
@@ -828,14 +828,13 @@ fn mouse_up(this: &mut Object, nsevent: id, button: PointerButton) {
             false
         };
         let event = mouse_pointer_event(nsevent, this as id, 0, focus, button, Vec2::ZERO);
-        let buttons = event.buttons; // Copy for check after event is consumed.
-        view_state.handler.pointer_up(event);
+        view_state.handler.pointer_up(&event);
         // If we have already received a mouseExited event then that means
         // we're still receiving mouse events because some buttons are being held down.
         // When the last held button is released and we haven't received a mouseEntered event,
         // then we will no longer receive mouse events until the next mouseEntered event
         // and need to inform the handler of the mouse leaving.
-        if view_state.mouse_left && buttons.is_empty() {
+        if view_state.mouse_left && event.buttons.is_empty() {
             view_state.handler.pointer_leave();
         }
     }
@@ -853,7 +852,7 @@ extern "C" fn mouse_move(this: &mut Object, _: Sel, nsevent: id) {
             PointerButton::None,
             Vec2::ZERO,
         );
-        view_state.handler.pointer_move(event);
+        view_state.handler.pointer_move(&event);
     }
 }
 
@@ -863,7 +862,7 @@ extern "C" fn mouse_enter(this: &mut Object, _sel: Sel, nsevent: id) {
         let view_state = &mut *(view_state as *mut ViewState);
         view_state.mouse_left = false;
         let event = mouse_pointer_event(nsevent, this, 0, false, PointerButton::None, Vec2::ZERO);
-        view_state.handler.pointer_move(event);
+        view_state.handler.pointer_move(&event);
     }
 }
 
@@ -898,7 +897,7 @@ extern "C" fn scroll_wheel(this: &mut Object, _: Sel, nsevent: id) {
             PointerButton::None,
             Vec2::new(dx, dy),
         );
-        view_state.handler.wheel(event);
+        view_state.handler.wheel(&event);
     }
 }
 
@@ -918,7 +917,7 @@ extern "C" fn key_down(this: &mut Object, _: Sel, nsevent: id) {
         &mut *(view_state as *mut ViewState)
     };
     if let Some(event) = view_state.keyboard_state.process_native_event(nsevent) {
-        if !view_state.handler.key_down(event) {
+        if !view_state.handler.key_down(&event) {
             // key down not handled; forward to text input system
             unsafe {
                 let events = NSArray::arrayWithObjects(nil, &[nsevent]);
@@ -934,7 +933,7 @@ extern "C" fn key_up(this: &mut Object, _: Sel, nsevent: id) {
         &mut *(view_state as *mut ViewState)
     };
     if let Some(event) = view_state.keyboard_state.process_native_event(nsevent) {
-        view_state.handler.key_up(event);
+        view_state.handler.key_up(&event);
     }
 }
 
@@ -945,9 +944,9 @@ extern "C" fn mods_changed(this: &mut Object, _: Sel, nsevent: id) {
     };
     if let Some(event) = view_state.keyboard_state.process_native_event(nsevent) {
         if event.state == KeyState::Down {
-            view_state.handler.key_down(event);
+            view_state.handler.key_down(&event);
         } else {
-            view_state.handler.key_up(event);
+            view_state.handler.key_up(&event);
         }
     }
 }

--- a/src/backend/wayland/input/mod.rs
+++ b/src/backend/wayland/input/mod.rs
@@ -389,7 +389,7 @@ impl SeatInfo {
         };
         match key_state {
             KeyState::Down => {
-                if handler.0.key_down(event.clone()) {
+                if handler.0.key_down(&event) {
                     return;
                 }
                 let update_can_do_nothing = matches!(
@@ -445,7 +445,7 @@ impl SeatInfo {
                     KeyboardHandled::NoUpdate => {}
                 }
             }
-            KeyState::Up => handler.0.key_up(event),
+            KeyState::Up => handler.0.key_up(&event),
         };
     }
 

--- a/src/backend/web/window.rs
+++ b/src/backend/web/window.rs
@@ -215,7 +215,7 @@ fn setup_mouse_down_callback(ws: &Rc<WindowState>) {
                 focus: false,
                 count,
             };
-            state.handler.borrow_mut().pointer_down(event);
+            state.handler.borrow_mut().pointer_down(&event);
         }
     });
 }
@@ -237,7 +237,7 @@ fn setup_mouse_up_callback(ws: &Rc<WindowState>) {
                 focus: false,
                 count: 0,
             };
-            state.handler.borrow_mut().pointer_up(event);
+            state.handler.borrow_mut().pointer_up(&event);
         }
     });
 }
@@ -258,7 +258,7 @@ fn setup_mouse_move_callback(ws: &Rc<WindowState>) {
             focus: false,
             count: 0,
         };
-        state.handler.borrow_mut().pointer_move(event);
+        state.handler.borrow_mut().pointer_move(&event);
     });
 }
 
@@ -295,7 +295,7 @@ fn setup_scroll_callback(ws: &Rc<WindowState>) {
             focus: false,
             count: 0,
         };
-        state.handler.borrow_mut().wheel(event);
+        state.handler.borrow_mut().wheel(&event);
     });
 }
 
@@ -314,7 +314,7 @@ fn setup_keyup_callback(ws: &Rc<WindowState>) {
     register_window_event_listener(ws, "keyup", move |event: web_sys::KeyboardEvent| {
         let modifiers = get_modifiers!(event);
         let kb_event = convert_keyboard_event(&event, modifiers, KeyState::Up);
-        state.handler.borrow_mut().key_up(kb_event);
+        state.handler.borrow_mut().key_up(&kb_event);
     });
 }
 

--- a/src/backend/windows/window.rs
+++ b/src/backend/windows/window.rs
@@ -920,7 +920,7 @@ impl WndProc for MyWndProc {
                                     }
                                 }
                                 KeyState::Up => {
-                                    s.handler.key_up(event);
+                                    s.handler.key_up(&event);
                                     if handle_menu {
                                         return true;
                                     }
@@ -976,7 +976,7 @@ impl WndProc for MyWndProc {
                         focus: false,
                         count: 0,
                     };
-                    s.handler.wheel(event);
+                    s.handler.wheel(&event);
                     true
                 });
                 if handled == Some(false) {
@@ -1026,7 +1026,7 @@ impl WndProc for MyWndProc {
                         focus: false,
                         count: 0,
                     };
-                    s.handler.pointer_move(event);
+                    s.handler.pointer_move(&event);
                 });
                 Some(0)
             }
@@ -1115,9 +1115,9 @@ impl WndProc for MyWndProc {
                         };
                         if count > 0 {
                             s.enter_pointer_capture(hwnd, button);
-                            s.handler.pointer_down(event);
+                            s.handler.pointer_down(&event);
                         } else {
-                            s.handler.pointer_up(event);
+                            s.handler.pointer_up(&event);
                             if s.exit_pointer_capture(button) {
                                 self.handle.borrow().defer(DeferredOp::ReleaseMouseCapture);
                             }

--- a/src/backend/x11/window.rs
+++ b/src/backend/x11/window.rs
@@ -776,7 +776,7 @@ impl Window {
             let event = xkb_state.key_event(scancode, keysym, key_state, is_repeat);
             match key_state {
                 KeyState::Down => {
-                    if handler.key_down(event.clone()) {
+                    if handler.key_down(&event) {
                         // The keypress was handled by the user, nothing to do
                         return;
                     }
@@ -795,7 +795,7 @@ impl Window {
                     handler.release_input_lock(field_token);
                 }
                 KeyState::Up => {
-                    handler.key_up(event);
+                    handler.key_up(&event);
                     self.reset_text_fields_if_needed(xkb_state, handler);
                 }
             }
@@ -964,7 +964,7 @@ impl Window {
         pointer_ev.buttons = pointer_ev.buttons.with(pointer_ev.button);
         // TODO: detect the count
         pointer_ev.count = 1;
-        self.with_handler(|h| h.pointer_down(pointer_ev));
+        self.with_handler(|h| h.pointer_down(&pointer_ev));
         Ok(())
     }
 
@@ -973,27 +973,27 @@ impl Window {
         // The xcb state includes the newly released button, but druid
         // doesn't want it.
         pointer_ev.buttons = pointer_ev.buttons.without(pointer_ev.button);
-        self.with_handler(|h| h.pointer_up(pointer_ev));
+        self.with_handler(|h| h.pointer_up(&pointer_ev));
         Ok(())
     }
 
     pub fn handle_touch_begin(&self, ev: &xinput::TouchBeginEvent) -> Result<(), Error> {
         let mut pointer_ev = self.pointer_touch_event(ev);
         pointer_ev.buttons = pointer_ev.buttons.with(pointer_ev.button);
-        self.with_handler(|h| h.pointer_down(pointer_ev));
+        self.with_handler(|h| h.pointer_down(&pointer_ev));
         Ok(())
     }
 
     pub fn handle_touch_update(&self, ev: &xinput::TouchBeginEvent) -> Result<(), Error> {
         let pointer_ev = self.pointer_touch_event(ev);
-        self.with_handler(|h| h.pointer_move(pointer_ev));
+        self.with_handler(|h| h.pointer_move(&pointer_ev));
         Ok(())
     }
 
     pub fn handle_touch_end(&self, ev: &xinput::TouchBeginEvent) -> Result<(), Error> {
         let mut pointer_ev = self.pointer_touch_event(ev);
         pointer_ev.buttons = pointer_ev.buttons.without(pointer_ev.button);
-        self.with_handler(|h| h.pointer_move(pointer_ev));
+        self.with_handler(|h| h.pointer_move(&pointer_ev));
         Ok(())
     }
 
@@ -1016,14 +1016,14 @@ impl Window {
         });
         pointer_ev.button = PointerButton::None;
 
-        self.with_handler(|h| h.wheel(pointer_ev));
+        self.with_handler(|h| h.wheel(&pointer_ev));
         Ok(())
     }
 
     pub fn handle_motion_notify(&self, ev: &xinput::ButtonPressEvent) -> Result<(), Error> {
         let mut pointer_ev = self.pointer_event(ev);
         pointer_ev.button = PointerButton::None;
-        self.with_handler(|h| h.pointer_move(pointer_ev));
+        self.with_handler(|h| h.pointer_move(&pointer_ev));
         Ok(())
     }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -579,7 +579,7 @@ pub(crate) fn simulate_input<H: WinHandler + ?Sized>(
     token: Option<TextFieldToken>,
     event: KeyEvent,
 ) -> bool {
-    if handler.key_down(event.clone()) {
+    if handler.key_down(&event) {
         return true;
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -653,14 +653,14 @@ pub trait WinHandler {
     ///
     /// Return `true` if the event is handled.
     #[allow(unused_variables)]
-    fn key_down(&mut self, event: KeyEvent) -> bool {
+    fn key_down(&mut self, event: &KeyEvent) -> bool {
         false
     }
 
     /// Called when a key is released. This corresponds to the `WM_KEYUP` message
     /// on Windows, or `keyUp(withEvent:)` on macOS.
     #[allow(unused_variables)]
-    fn key_up(&mut self, event: KeyEvent) {}
+    fn key_up(&mut self, event: &KeyEvent) {}
 
     /// Take a lock for the text document specified by `token`.
     ///
@@ -705,23 +705,23 @@ pub trait WinHandler {
     ///
     /// [WheelEvent]: https://w3c.github.io/uievents/#event-type-wheel
     #[allow(unused_variables)]
-    fn wheel(&mut self, event: PointerEvent) {}
+    fn wheel(&mut self, event: &PointerEvent) {}
 
     /// Called when a pointer moves.
     #[allow(unused_variables)]
-    fn pointer_move(&mut self, event: PointerEvent) {}
+    fn pointer_move(&mut self, event: &PointerEvent) {}
 
     /// Called when a pointer goes "down."
     ///
     /// This includes things like mouse button presses, and styli coming in contact with screens.
     #[allow(unused_variables)]
-    fn pointer_down(&mut self, event: PointerEvent) {}
+    fn pointer_down(&mut self, event: &PointerEvent) {}
 
     /// Called when a pointer goes "up."
     ///
     /// This includes things like mouse button releases, and styli lifting from screens.
     #[allow(unused_variables)]
-    fn pointer_up(&mut self, event: PointerEvent) {}
+    fn pointer_up(&mut self, event: &PointerEvent) {}
 
     /// Called when a pointer has left the application window.
     fn pointer_leave(&mut self) {}


### PR DESCRIPTION
This reverts #129 (87b132c) which had changed `PointerEvent` to pass by value rather than ref.

Since `KeyboardEvent` has a cost to clone / copy, this may be a better approach.