### PR TITLE
Upgrade `actions/checkout` to `v4`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     name: cargo fmt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
@@ -41,7 +41,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     name: cargo clippy + test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: install additional linux dependencies
         run: |
@@ -87,7 +87,7 @@ jobs:
 #    runs-on: macOS-latest
 #    name: cargo test (wasm32)
 #    steps:
-#      - uses: actions/checkout@v3
+#      - uses: actions/checkout@v4
 #
 #      - name: install wasm-pack
 #        uses: jetli/wasm-pack-action@v0.3.0
@@ -118,7 +118,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: install additional linux dependencies
         run: |


### PR DESCRIPTION
Simple maintenance, primary [change](https://github.com/actions/checkout/releases/tag/v4.0.0) is `node` upgrade under the hood.