### PR TITLE
Bump Rust stable toolchain to 1.73.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ env:
   # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
   # come automatically. If the version specified here is no longer the latest stable version,
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
-  RUST_STABLE_VER: "1.72" # In quotes because otherwise 1.70 would be interpreted as 1.7
+  RUST_STABLE_VER: "1.73" # In quotes because otherwise 1.70 would be interpreted as 1.7
 
 # Rationale
 #

--- a/examples/shared_app_handle.rs
+++ b/examples/shared_app_handle.rs
@@ -9,11 +9,8 @@ fn main() {
     // Get a handle from the app
     let handle = app.get_handle().expect("failed to get app handle");
 
-    // Spawn a new thread where we will use the app handle
+    // Spawn a new thread and move the app handle there
     thread::spawn(move || {
-        // This just explicitly shows that the handle gets moved into this closure
-        let handle = handle;
-
         // Take a quick break
         println!("Starting sleep");
         thread::sleep(Duration::from_secs(5));


### PR DESCRIPTION
Removed the redundant redefinition of `handle` from the `shared_app_handle` example to satisfy Clippy 1.73.