### PR TITLE
Update to AccessKit 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,13 +56,13 @@ memchr = "2.5"
 
 # Optional dependencies
 raw-window-handle = { version = "0.5.0", default_features = false }
-accesskit = { version = "0.11.0", optional = true }
+accesskit = { version = "0.12.0", optional = true }
 once_cell = { version = "1", optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
 scopeguard = "1.1.0"
 wio = "0.2.2"
-accesskit_windows = { version = "0.14.0", optional = true }
+accesskit_windows = { version = "0.15.0", optional = true }
 once_cell = "1"
 
 [target.'cfg(target_os="windows")'.dependencies.winapi]
@@ -93,7 +93,7 @@ cocoa = "0.25.0"
 objc = "0.2.7"
 core-graphics = "0.23.0"
 bitflags = "2.0.0"
-accesskit_macos = { version = "0.9.0", optional = true }
+accesskit_macos = { version = "0.10.0", optional = true }
 
 [target.'cfg(any(target_os = "freebsd", target_os="linux", target_os="openbsd"))'.dependencies]
 ashpd = { version = "0.5", optional = true }

--- a/examples/edit_text.rs
+++ b/examples/edit_text.rs
@@ -327,7 +327,16 @@ impl WinHandler for WindowState {
     #[cfg(feature = "accesskit")]
     fn accesskit_tree(&mut self) -> TreeUpdate {
         // TODO: Construct a real TreeUpdate
-        TreeUpdate::default()
+        use accesskit::{NodeBuilder, NodeClassSet, NodeId, Role, Tree};
+        let builder = NodeBuilder::new(Role::Window);
+        let mut node_classes = NodeClassSet::new();
+        let node = builder.build(&mut node_classes);
+        const WINDOW_ID: NodeId = NodeId(0);
+        TreeUpdate {
+            nodes: vec![(WINDOW_ID, node)],
+            tree: Some(Tree::new(WINDOW_ID)),
+            focus: WINDOW_ID,
+        }
     }
 
     fn size(&mut self, size: Size) {

--- a/examples/pen.rs
+++ b/examples/pen.rs
@@ -144,7 +144,16 @@ impl WinHandler for WindowState {
     #[cfg(feature = "accesskit")]
     fn accesskit_tree(&mut self) -> TreeUpdate {
         // TODO: Construct a real TreeUpdate
-        TreeUpdate::default()
+        use accesskit::{NodeBuilder, NodeClassSet, NodeId, Role, Tree};
+        let builder = NodeBuilder::new(Role::Window);
+        let mut node_classes = NodeClassSet::new();
+        let node = builder.build(&mut node_classes);
+        const WINDOW_ID: NodeId = NodeId(0);
+        TreeUpdate {
+            nodes: vec![(WINDOW_ID, node)],
+            tree: Some(Tree::new(WINDOW_ID)),
+            focus: WINDOW_ID,
+        }
     }
 
     fn idle(&mut self, _: IdleToken) {

--- a/examples/shello.rs
+++ b/examples/shello.rs
@@ -132,7 +132,16 @@ impl WinHandler for WindowState {
     #[cfg(feature = "accesskit")]
     fn accesskit_tree(&mut self) -> TreeUpdate {
         // TODO: Construct a real TreeUpdate
-        TreeUpdate::default()
+        use accesskit::{NodeBuilder, NodeClassSet, NodeId, Role, Tree};
+        let builder = NodeBuilder::new(Role::Window);
+        let mut node_classes = NodeClassSet::new();
+        let node = builder.build(&mut node_classes);
+        const WINDOW_ID: NodeId = NodeId(0);
+        TreeUpdate {
+            nodes: vec![(WINDOW_ID, node)],
+            tree: Some(Tree::new(WINDOW_ID)),
+            focus: WINDOW_ID,
+        }
     }
 
     fn idle(&mut self, _: IdleToken) {}

--- a/examples/wgpu-triangle/main.rs
+++ b/examples/wgpu-triangle/main.rs
@@ -188,7 +188,16 @@ impl WinHandler for WindowState {
     #[cfg(feature = "accesskit")]
     fn accesskit_tree(&mut self) -> TreeUpdate {
         // TODO: Construct a real TreeUpdate
-        TreeUpdate::default()
+        use accesskit::{NodeBuilder, NodeClassSet, NodeId, Role, Tree};
+        let builder = NodeBuilder::new(Role::Window);
+        let mut node_classes = NodeClassSet::new();
+        let node = builder.build(&mut node_classes);
+        const WINDOW_ID: NodeId = NodeId(0);
+        TreeUpdate {
+            nodes: vec![(WINDOW_ID, node)],
+            tree: Some(Tree::new(WINDOW_ID)),
+            focus: WINDOW_ID,
+        }
     }
 
     fn idle(&mut self, _: IdleToken) {}


### PR DESCRIPTION
The biggest change in glazier itself is that glazier, rather than the application, is now responsible for telling AccessKit about the focus state of the window, because this is now tracked in the AccessKit platform adapter rather than in the tree itself. Most of the other breaking API changes affected the example.