### PR TITLE
Fix Cargo.toml warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lazy_static = "1.4.0"
 cfg-if = "1.0.0"
 instant = { version = "0.1.6", features = ["wasm-bindgen"] }
 anyhow = "1.0.32"
-keyboard-types = { version = "0.7", default_features = false }
+keyboard-types = { version = "0.7", default-features = false }
 memchr = "2.5"
 
 # Optional dependencies
-raw-window-handle = { version = "0.5.0", default_features = false }
+raw-window-handle = { version = "0.5.0", default-features = false }
 accesskit = { version = "0.12.0", optional = true }
 once_cell = { version = "1", optional = true }
 
@@ -122,7 +122,7 @@ smithay-client-toolkit = { version = "0.17.0", optional = true, default-features
 ] }
 # Wayland dependencies
 # Needed for supporting RawWindowHandle
-wayland-backend = { version = "0.1.0", default_features = false, features = [
+wayland-backend = { version = "0.1.0", default-features = false, features = [
     "client_system",
 ], optional = true }
 


### PR DESCRIPTION
warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `keyboard-types` dependency)
warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `raw-window-handle` dependency)
warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `wayland-backend` dependency)
